### PR TITLE
Fix missing nodejs in Docker + utility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+build-container:
+	docker build -t streaming-community-api .
+
+run-container:
+	docker run --rm -it -p 8000:8000 -v ${LOCAL_DIR}:/app/Video -v ./config.json:/app/config.json streaming-community-api

--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ make build-container
 make LOCAL_DIR=/path/to/download run-container
 ```
 
+The `run-container` command mounts also the `config.json` file, so any change to the configuration file is reflected immediately without having to rebuild the image.
+
 ## Tutorial
 
 For a detailed walkthrough, refer to the [video tutorial](https://www.youtube.com/watch?v=Ok7hQCgxqLg&ab_channel=Nothing)

--- a/README.md
+++ b/README.md
@@ -209,6 +209,17 @@ By default the videos will be saved in `/app/Video` inside the container, if you
 docker run -it -p 8000:8000 -v /path/to/download:/app/Video streaming-community-api
 ```
 
+### Docker quick setup with Make
+
+Inside the Makefile (install `make`) are already configured two commands to build and run the container:
+
+```
+make build-container
+
+# set your download directory as ENV variable
+make LOCAL_DIR=/path/to/download run-container
+```
+
 ## Tutorial
 
 For a detailed walkthrough, refer to the [video tutorial](https://www.youtube.com/watch?v=Ok7hQCgxqLg&ab_channel=Nothing)

--- a/config.json
+++ b/config.json
@@ -18,7 +18,7 @@
     },
     "M3U8_DOWNLOAD": {
         "tdqm_workers": 2,
-        "tqdm_delay": 0.01,
+        "tqdm_delay": 0.6,
         "tqdm_use_large_bar": true,
         "download_video": true,
         "download_audio": true,

--- a/dockerfile
+++ b/dockerfile
@@ -1,8 +1,5 @@
 FROM python:3.11-slim
 
-COPY . /app
-WORKDIR /app
-
 ENV TEMP /tmp
 RUN mkdir -p $TEMP
 
@@ -13,7 +10,11 @@ RUN apt-get update && apt-get install -y \
     libffi-dev \
     python3-dev \
     libxml2-dev \
-    libxslt1-dev
+    libxslt1-dev \
+    nodejs
+
+COPY . /app
+WORKDIR /app
 
 RUN pip install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
- added nodejs to docker
- rearranged commands in dockerfile to improve image layers caching
- Makefile to quickly build and launch the image
- Readme changes to describe how to use the makefile
- changed default wait time for M3U8_DOWNLOAD to 0.6 seconds (from 0.01) to avoid problems with server limiting