### PR TITLE
Aggiunto `python-qbittorrent`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ psutil
 unidecode
 fake-useragent
 qbittorrent-api
+python-qbittorrent


### PR DESCRIPTION
Senza causava questo errore: No module named 'qbittorrent'