### PR TITLE
Risolto problema con il messaggio di selezione degli episodi per il bot Telegram (discusso su Discord)

### DIFF
--- a/StreamingCommunity/Api/Site/streamingcommunity/series.py
+++ b/StreamingCommunity/Api/Site/streamingcommunity/series.py
@@ -185,7 +185,11 @@ def download_series(select_season: MediaItem) -> None:
 
         index_season_selected = bot.ask(
             "select_title_episode",
-            "Inserisci il numero della stagione (es. 1), * per scaricare tutte le stagioni, (es. 1-2) per un intervallo di stagioni, o (es. 3-*) per scaricare dalla stagione specificata fino alla fine",
+            "Menu di selezione delle stagioni\n\n"
+            "- Inserisci il numero della stagione (ad esempio, 1)\n"
+            "- Inserisci * per scaricare tutte le stagioni\n"
+            "- Inserisci un intervallo di stagioni (ad esempio, 1-2) per scaricare da una stagione all'altra\n"
+            "- Inserisci (ad esempio, 3-*) per scaricare dalla stagione specificata fino alla fine della serie",
             None
         )
 

--- a/StreamingCommunity/Util/table.py
+++ b/StreamingCommunity/Util/table.py
@@ -195,7 +195,7 @@ class TVShowManager:
                                    "- Inserisci (ad esempio, 3-*) per scaricare dall'episodio specificato fino alla fine della serie"
                     
                     if is_telegram:
-                        key = bot.ask("select_title_episode", prompt_msg, None)
+                        key = bot.ask("select_title_episode", telegram_msg, None)
                     else:
                         key = Prompt.ask(prompt_msg)
                 else:

--- a/StreamingCommunity/Util/table.py
+++ b/StreamingCommunity/Util/table.py
@@ -147,9 +147,14 @@ class TVShowManager:
                 if not force_int_input:
                     prompt_msg = ("\n[cyan]Insert media index [yellow](e.g., 1), [red]* [cyan]to download all media, "
                                 "[yellow](e.g., 1-2) [cyan]for a range of media, or [yellow](e.g., 3-*) [cyan]to download from a specific index to the end")
+                    telegram_msg = "Menu di selezione degli episodi: \n\n" \
+                                   "- Inserisci il numero dell'episodio (ad esempio, 1)\n" \
+                                   "- Inserisci * per scaricare tutti gli episodi\n" \
+                                   "- Inserisci un intervallo di episodi (ad esempio, 1-2) per scaricare da un episodio all'altro\n" \
+                                   "- Inserisci (ad esempio, 3-*) per scaricare dall'episodio specificato fino alla fine della serie"
                     
                     if is_telegram:
-                        key = bot.ask("select_title_episode", prompt_msg, None)
+                        key = bot.ask("select_title_episode", telegram_msg, None)
                     else:
                         key = Prompt.ask(prompt_msg)
                 else:
@@ -183,6 +188,11 @@ class TVShowManager:
                 if not force_int_input:
                     prompt_msg = ("\n[cyan]Insert media index [yellow](e.g., 1), [red]* [cyan]to download all media, "
                                 "[yellow](e.g., 1-2) [cyan]for a range of media, or [yellow](e.g., 3-*) [cyan]to download from a specific index to the end")
+                    telegram_msg = "Menu di selezione degli episodi: \n\n" \
+                                   "- Inserisci il numero dell'episodio (ad esempio, 1)\n" \
+                                   "- Inserisci * per scaricare tutti gli episodi\n" \
+                                   "- Inserisci un intervallo di episodi (ad esempio, 1-2) per scaricare da un episodio all'altro\n" \
+                                   "- Inserisci (ad esempio, 3-*) per scaricare dall'episodio specificato fino alla fine della serie"
                     
                     if is_telegram:
                         key = bot.ask("select_title_episode", prompt_msg, None)


### PR DESCRIPTION
Questa pull request risolve il problema relativo al messaggio che veniva inviato dal bot Telegram, che non era corretto e tantomeno in italiano. 
Il messaggio di selezione degli episodi è stato aggiornato per fornire istruzioni chiare agli utenti in lingua italiana. Il nuovo messaggio include le seguenti informazioni:
- Indicazione per inserire il numero dell'episodio.
- Opzione per scaricare tutti gli episodi.
- Supporto per selezionare un intervallo di episodi.
- Opzione per scaricare dagli episodi a partire da un numero specifico fino alla fine della serie.

Messaggio che si riceveva prima:
![image](https://github.com/user-attachments/assets/27fc587a-3bad-4956-919e-bef148a0f338)

Messaggio che si riceve adesso:
![image](https://github.com/user-attachments/assets/219ea670-89d3-4ed0-93fc-1a66b7c9d9a1)
