### PR TITLE
refactor: streamline proxy checking in search function

### DIFF
--- a/StreamingCommunity/Api/Site/streamingcommunity/__init__.py
+++ b/StreamingCommunity/Api/Site/streamingcommunity/__init__.py
@@ -121,14 +121,16 @@ def search(string_to_search: str = None, get_onlyDatabase: bool = False, direct_
     if site_constant.TELEGRAM_BOT:
         bot = get_bot_instance()
 
+    # Check proxy if not already set
+    finder = ProxyFinder(site_constant.FULL_URL)
+    proxy = finder.find_fast_proxy()
+    
     if direct_item:
         select_title_obj = MediaItem(**direct_item)
         process_search_result(select_title_obj, selections, proxy)
         return
     
-    # Check proxy if not already set
-    finder = ProxyFinder(site_constant.FULL_URL)
-    proxy = finder.find_fast_proxy()
+
 
     actual_search_query = get_user_input(string_to_search)
 


### PR DESCRIPTION
Resolve #327 

How to reproduce the error:

- create and run from a virtualenv
- run using globalsearch
streamingcommunity --not_close true --global -s moviename

Error:

Error processing download: cannot access local variable 'proxy' where it is not associated with a value
[global_search.py:320 - process_selected_item() ] 2025-05-21 22:36:59,172 - ERROR - Download processing error
Traceback (most recent call last):
  File "/usr/local/sbin/StreamingCommunity/venv/lib/python3.12/site-packages/StreamingCommunity/global_search.py", line 316, in process_selected_item
    func(direct_item=selected_item)
  File "/usr/local/sbin/StreamingCommunity/venv/lib/python3.12/site-packages/StreamingCommunity/Api/Site/streamingcommunity/__init__.py", line 130, in search
    process_search_result(select_title_obj, selections, proxy)
                                                        ^^^^^
UnboundLocalError: cannot access local variable 'proxy' where it is not associated with a value