### PR TITLE
Dns check refactor

### DIFF
--- a/StreamingCommunity/Api/Site/streamingcommunity/__init__.py
+++ b/StreamingCommunity/Api/Site/streamingcommunity/__init__.py
@@ -121,14 +121,16 @@ def search(string_to_search: str = None, get_onlyDatabase: bool = False, direct_
     if site_constant.TELEGRAM_BOT:
         bot = get_bot_instance()
 
+    # Check proxy if not already set
+    finder = ProxyFinder(site_constant.FULL_URL)
+    proxy = finder.find_fast_proxy()
+    
     if direct_item:
         select_title_obj = MediaItem(**direct_item)
         process_search_result(select_title_obj, selections, proxy)
         return
     
-    # Check proxy if not already set
-    finder = ProxyFinder(site_constant.FULL_URL)
-    proxy = finder.find_fast_proxy()
+
 
     actual_search_query = get_user_input(string_to_search)
 

--- a/StreamingCommunity/Util/os.py
+++ b/StreamingCommunity/Util/os.py
@@ -323,17 +323,20 @@ class InternManager():
     def check_dns_resolve(self):
         """
         Check if the system's current DNS server can resolve a domain name.
+        Works on both Windows and Unix-like systems.
         
         Returns:
             bool: True if the current DNS server can resolve a domain name,
                     False if can't resolve or in case of errors
         """
+        
+        test_domains = ["github.com", "google.com", "microsoft.com", "amazon.com"]
         try:
-            resolver = dns.resolver.Resolver()
-            # Simple DNS resolution test - will raise an exception if it fails
-            resolver.resolve("github.com")
+            for domain in test_domains:
+                # socket.gethostbyname() works consistently across all platforms
+                os.socket.gethostbyname(domain)
             return True
-        except Exception:
+        except (os.socket.gaierror, os.socket.error):
             return False
 
 class OsSummary:

--- a/StreamingCommunity/Util/os.py
+++ b/StreamingCommunity/Util/os.py
@@ -283,43 +283,58 @@ class InternManager():
         else:
             return f"{bytes / (1024 * 1024):.2f} MB/s"
 
-    def check_dns_provider(self):
+    # def check_dns_provider(self):
+    #     """
+    #     Check if the system's current DNS server matches any known DNS providers.
+        
+    #     Returns:
+    #         bool: True if the current DNS server matches a known provider,
+    #               False if no match is found or in case of errors
+    #     """
+    #     dns_providers = {
+    #         "Cloudflare": ["1.1.1.1", "1.0.0.1"],
+    #         "Google": ["8.8.8.8", "8.8.4.4"],
+    #         "OpenDNS": ["208.67.222.222", "208.67.220.220"],
+    #         "Quad9": ["9.9.9.9", "149.112.112.112"],
+    #         "AdGuard": ["94.140.14.14", "94.140.15.15"],
+    #         "Comodo": ["8.26.56.26", "8.20.247.20"],
+    #         "Level3": ["209.244.0.3", "209.244.0.4"],
+    #         "Norton": ["199.85.126.10", "199.85.127.10"],
+    #         "CleanBrowsing": ["185.228.168.9", "185.228.169.9"],
+    #         "Yandex": ["77.88.8.8", "77.88.8.1"]
+    #     }
+        
+    #     try:
+    #         resolver = dns.resolver.Resolver()
+    #         nameservers = resolver.nameservers
+            
+    #         if not nameservers:
+    #             return False
+                
+    #         for server in nameservers:
+    #             for provider, ips in dns_providers.items():
+    #                 if server in ips:
+    #                     return True
+    #         return False
+            
+    #     except Exception:
+    #         return False
+
+    def check_dns_resolve(self):
         """
-        Check if the system's current DNS server matches any known DNS providers.
+        Check if the system's current DNS server can resolve a domain name.
         
         Returns:
-            bool: True if the current DNS server matches a known provider,
-                  False if no match is found or in case of errors
+            bool: True if the current DNS server can resolve a domain name,
+                    False if can't resolve or in case of errors
         """
-        dns_providers = {
-            "Cloudflare": ["1.1.1.1", "1.0.0.1"],
-            "Google": ["8.8.8.8", "8.8.4.4"],
-            "OpenDNS": ["208.67.222.222", "208.67.220.220"],
-            "Quad9": ["9.9.9.9", "149.112.112.112"],
-            "AdGuard": ["94.140.14.14", "94.140.15.15"],
-            "Comodo": ["8.26.56.26", "8.20.247.20"],
-            "Level3": ["209.244.0.3", "209.244.0.4"],
-            "Norton": ["199.85.126.10", "199.85.127.10"],
-            "CleanBrowsing": ["185.228.168.9", "185.228.169.9"],
-            "Yandex": ["77.88.8.8", "77.88.8.1"]
-        }
-        
         try:
             resolver = dns.resolver.Resolver()
-            nameservers = resolver.nameservers
-            
-            if not nameservers:
-                return False
-                
-            for server in nameservers:
-                for provider, ips in dns_providers.items():
-                    if server in ips:
-                        return True
-            return False
-            
+            # Simple DNS resolution test - will raise an exception if it fails
+            resolver.resolve("github.com")
+            return True
         except Exception:
             return False
-
 
 class OsSummary:
     def __init__(self):

--- a/StreamingCommunity/Util/os.py
+++ b/StreamingCommunity/Util/os.py
@@ -12,7 +12,7 @@ import inspect
 import subprocess
 import contextlib
 import importlib.metadata
-
+import socket
 
 # External library
 from unidecode import unidecode
@@ -334,9 +334,9 @@ class InternManager():
         try:
             for domain in test_domains:
                 # socket.gethostbyname() works consistently across all platforms
-                os.socket.gethostbyname(domain)
+                socket.gethostbyname(domain)
             return True
-        except (os.socket.gaierror, os.socket.error):
+        except (socket.gaierror, socket.error):
             return False
 
 class OsSummary:

--- a/StreamingCommunity/run.py
+++ b/StreamingCommunity/run.py
@@ -210,7 +210,19 @@ def main(script_id = 0):
     log_not = Logger()
     initialize()
     
-    if not internet_manager.check_dns_provider():
+    # if not internet_manager.check_dns_provider():
+    #     print()
+    #     console.print("[red]❌ ERROR: DNS configuration is required!")
+    #     console.print("[red]The program cannot function correctly without proper DNS settings.")
+    #     console.print("[yellow]Please configure one of these DNS servers:")
+    #     console.print("[blue]• Cloudflare (1.1.1.1) 'https://developers.cloudflare.com/1.1.1.1/setup/windows/'")
+    #     console.print("[blue]• Quad9 (9.9.9.9) 'https://docs.quad9.net/Setup_Guides/Windows/Windows_10/'")
+    #     console.print("\n[yellow]⚠️ The program will not work until you configure your DNS settings.")
+
+    #     time.sleep(2)        
+    #     msg.ask("[yellow]Press Enter to continue ...")
+
+    if not internet_manager.check_dns_resolve():
         print()
         console.print("[red]❌ ERROR: DNS configuration is required!")
         console.print("[red]The program cannot function correctly without proper DNS settings.")
@@ -219,8 +231,7 @@ def main(script_id = 0):
         console.print("[blue]• Quad9 (9.9.9.9) 'https://docs.quad9.net/Setup_Guides/Windows/Windows_10/'")
         console.print("\n[yellow]⚠️ The program will not work until you configure your DNS settings.")
 
-        time.sleep(2)        
-        msg.ask("[yellow]Press Enter to continue ...")
+        os._exit(0)
 
     # Load search functions
     search_functions = load_search_functions()


### PR DESCRIPTION
Checking the presence of dns servers by comparing an ip list could be inaccurate, the function is called after making external calls by ConfigManager to the APIs on github:

https://raw.githubusercontent.com/Arrowar/StreamingCommunity/refs/heads/main/config.json

that could fail anyway before the check_dns_provider call. I propose a real dns resolution that can be successful even in systems where the DNS server (provider) is a localhost dns resolver (127.0.0.1), if this fails the program executes an exit(0) since in any case the calls to the APIs executed previously have failed and it makes no sense to continue the search execution.
Also suggest to use this check_dns_resolve function also on ConfigManager to prevent useless calls to unreachable API




A further improvement could be to try to actually resolve the needed hosts from a known list instead of testing the single domain as proposed in the pull, for example:


Instead of:
resolver.resolve("github.com")

Implement this:
        test_domains = ["domain1.com", "domain2.com", "domain3.com", "domain4.com"]
        for domain in test_domains:
            resolver.resolve(domain)  #

which are the domains on which it is conceivable to do the searches