### PR TITLE
Aggiunta variabile d'ambiente per la GUI

### DIFF
--- a/GUI/README.md
+++ b/GUI/README.md
@@ -1,6 +1,10 @@
-Web GUI per ricerca e download.
+# Web GUI per ricerca e download
 
-Comandi rapidi:
+## Comandi rapidi:
 - Installazione deps: `pip install -r .\GUI\requirements.txt`
 - Esecuzione migrazioni: `python GUI/manage.py migrate`
 - Avvio dev: `python GUI/manage.py runserver 0.0.0.0:8000`
+
+## Problemi di CSRF
+- In caso di problemi quando si effettua una ricerca al di fuori della propria rete (magari sotto un reverse proxy) impostare la variabile d'ambiente `CSRF_TRUSTED_ORIGINS`
+    > Esempio: `CSRF_TRUSTED_ORIGINS="http://127.0.0.1:8000 https://altrodominio.it"`

--- a/GUI/webgui/settings.py
+++ b/GUI/webgui/settings.py
@@ -70,3 +70,5 @@ STATIC_ROOT = BASE_DIR / "static"
 STATICFILES_DIRS = [BASE_DIR / "assets"] if (BASE_DIR / "assets").exists() else []
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+CSRF_TRUSTED_ORIGINS = os.environ.get("CSRF_TRUSTED_ORIGINS", "").split()


### PR DESCRIPTION
Usando l'app sotto un reverse proxy (personalmente uso [Nginx Proxy Manager](https://nginxproxymanager.com/)) ho notato di avere problemi di CSRF. Quindi in locale funzionava correttamente, al di fuori della rete avevo questo problema:

```
Origin checking failed - https://streamingcommunity.gianlucalauro.com does not match any trusted origins.
    
In general, this can occur when there is a genuine Cross Site Request Forgery, or when [Django’s CSRF mechanism](https://docs.djangoproject.com/en/4.2/ref/csrf/) has not been used correctly. For POST forms, you need to ensure:

Your browser is accepting cookies.
The view function passes a request to the template’s [render](https://docs.djangoproject.com/en/dev/topics/templates/#django.template.backends.base.Template.render) method.
In the template, there is a {% csrf_token %} template tag inside each POST form that targets an internal URL.
If you are not using CsrfViewMiddleware, then you must use csrf_protect on any views that use the csrf_token template tag, as well as those that accept the POST data.
The form has a valid CSRF token. After logging in in another browser tab or hitting the back button after a login, you may need to reload the page with the form, because the token is rotated after a login.
You’re seeing the help section of this page because you have DEBUG = True in your Django settings file. Change that to False, and only the initial error message will be displayed.

You can customize this page using the CSRF_FAILURE_VIEW setting.
```

### Soluzione

Ho impsotato una variabile d'ambiente (opzionale) grazie alla quale da permessi a più domini.
