### PR TITLE
Nominazione file ottimizzata per jellyfin e Plex e codifica con meno artefatti 

### DIFF
--- a/config.json
+++ b/config.json
@@ -12,7 +12,7 @@
         "movie_folder_name": "Movie",
         "serie_folder_name": "Serie",
         "anime_folder_name": "Anime",
-        "map_episode_name": "E%(episode)_%(episode_name)",
+        "map_episode_name": "S%(season)E%(episode).%(episode_name)",
         "add_siteName": false
     },
     "QBIT_CONFIG": {
@@ -44,7 +44,7 @@
         "use_acodec": true,
         "use_bitrate": true,
         "use_gpu": false,
-        "default_preset": "ultrafast",
+        "default_preset": "slow",
         "force_resolution": "Best"
     },
     "REQUESTS": {


### PR DESCRIPTION
Otimizzazione nominazione dei file per i media manager, in allegato il config.json già modificato.

ci sono due cambiamenti principali, l'intitolazione (quella consigliata incollata di seguiti)

         "map_episode_name": "S%(season)E%(episode).%(episode_name)",


ottimizzazione m3u8 convertono (con ultrafast ci sono un pò di artefatti) consiglio slow (anche per cup, h265 è supportato ovunque ormai), quindi si avrebbe una cosa del genere:

        "default_preset": "slow",


[config.json](https://github.com/user-attachments/files/22862698/config.json)
