### PR TITLE
fix M3U8_CONVERSION extension for StreamingCommunity

### DIFF
--- a/StreamingCommunity/Api/Site/streamingcommunity/film.py
+++ b/StreamingCommunity/Api/Site/streamingcommunity/film.py
@@ -56,7 +56,7 @@ def download_film(select_title: MediaItem) -> str:
         return None
 
     # Define the filename and path for the downloaded film
-    title_name = os_manager.get_sanitize_file(select_title.name, select_title.date) + extension_output
+    title_name = f"{os_manager.get_sanitize_file(select_title.name, select_title.date)}.{extension_output}"
     mp4_path = os.path.join(site_constant.MOVIE_FOLDER, title_name.replace(extension_output, ""))
 
     # Download the film using the m3u8 playlist, and output filename


### PR DESCRIPTION
In Streamingcommunity, `film.py` e `series.py` si comportavano diversamente per come gestivano l'estensione del file di output. Dato che la config `M3U8_CONVERSION.extension` attualmente non include il punto, l'ho aggiunto in `film.py`