### PR TITLE
Add .ignore file to temp directory to prevent indexing by Jellyfin

### DIFF
--- a/StreamingCommunity/Lib/Downloader/HLS/downloader.py
+++ b/StreamingCommunity/Lib/Downloader/HLS/downloader.py
@@ -101,6 +101,10 @@ class PathManager:
         os.makedirs(self.temp_dir, exist_ok=True)
         for subdir in ['video', 'audio', 'subs']:
             os.makedirs(os.path.join(self.temp_dir, subdir), exist_ok=True)
+        # Create a .ignore file to prevent temp directory from being indexed by Jellyfin
+        ignore_path = os.path.join(self.temp_dir, '.ignore')
+        with open(ignore_path, 'a', encoding='utf-8'):
+            os.utime(ignore_path, None)
 
     def move_final_file(self, final_file: str):
         """Moves the final merged file to the desired output location."""

--- a/StreamingCommunity/Lib/Downloader/HLS/downloader.py
+++ b/StreamingCommunity/Lib/Downloader/HLS/downloader.py
@@ -35,6 +35,7 @@ DOWNLOAD_SPECIFIC_SUBTITLE = config_manager.get_list('M3U8_DOWNLOAD', 'specific_
 MERGE_SUBTITLE = config_manager.get_bool('M3U8_DOWNLOAD', 'merge_subs')
 CLEANUP_TMP = config_manager.get_bool('M3U8_DOWNLOAD', 'cleanup_tmp_folder')
 GET_ONLY_LINK = config_manager.get_int('M3U8_DOWNLOAD', 'get_only_link')
+IGNORE_JELLYFIN_INDEXING = config_manager.get_bool('M3U8_DOWNLOAD', 'ignore_jellyfin_indexing')
 FILTER_CUSTOM_RESOLUTION = str(config_manager.get('M3U8_CONVERSION', 'force_resolution')).strip().lower()
 EXTENSION_OUTPUT = config_manager.get("M3U8_CONVERSION", "extension")
 
@@ -102,9 +103,10 @@ class PathManager:
         for subdir in ['video', 'audio', 'subs']:
             os.makedirs(os.path.join(self.temp_dir, subdir), exist_ok=True)
         # Create a .ignore file to prevent temp directory from being indexed by Jellyfin
-        ignore_path = os.path.join(self.temp_dir, '.ignore')
-        with open(ignore_path, 'a', encoding='utf-8'):
-            os.utime(ignore_path, None)
+        if IGNORE_JELLYFIN_INDEXING:
+            ignore_path = os.path.join(self.temp_dir, '.ignore')
+            with open(ignore_path, 'a', encoding='utf-8'):
+                os.utime(ignore_path, None)
 
     def move_final_file(self, final_file: str):
         """Moves the final merged file to the desired output location."""

--- a/StreamingCommunity/Lib/Downloader/HLS/downloader.py
+++ b/StreamingCommunity/Lib/Downloader/HLS/downloader.py
@@ -103,10 +103,9 @@ class PathManager:
             os.makedirs(os.path.join(self.temp_dir, subdir), exist_ok=True)
             
         # Create a .ignore file to prevent temp directory from being indexed by Jellyfin
-        if IGNORE_JELLYFIN_INDEXING:
-            ignore_path = os.path.join(self.temp_dir, '.ignore')
-            with open(ignore_path, 'a', encoding='utf-8'):
-                os.utime(ignore_path, None)
+        ignore_path = os.path.join(self.temp_dir, '.ignore')
+        with open(ignore_path, 'a', encoding='utf-8'):
+            os.utime(ignore_path, None)
 
     def move_final_file(self, final_file: str):
         """Moves the final merged file to the desired output location."""

--- a/StreamingCommunity/Lib/Downloader/HLS/downloader.py
+++ b/StreamingCommunity/Lib/Downloader/HLS/downloader.py
@@ -35,7 +35,6 @@ DOWNLOAD_SPECIFIC_SUBTITLE = config_manager.get_list('M3U8_DOWNLOAD', 'specific_
 MERGE_SUBTITLE = config_manager.get_bool('M3U8_DOWNLOAD', 'merge_subs')
 CLEANUP_TMP = config_manager.get_bool('M3U8_DOWNLOAD', 'cleanup_tmp_folder')
 GET_ONLY_LINK = config_manager.get_int('M3U8_DOWNLOAD', 'get_only_link')
-IGNORE_JELLYFIN_INDEXING = config_manager.get_bool('M3U8_DOWNLOAD', 'ignore_jellyfin_indexing')
 FILTER_CUSTOM_RESOLUTION = str(config_manager.get('M3U8_CONVERSION', 'force_resolution')).strip().lower()
 EXTENSION_OUTPUT = config_manager.get("M3U8_CONVERSION", "extension")
 
@@ -102,6 +101,7 @@ class PathManager:
         os.makedirs(self.temp_dir, exist_ok=True)
         for subdir in ['video', 'audio', 'subs']:
             os.makedirs(os.path.join(self.temp_dir, subdir), exist_ok=True)
+            
         # Create a .ignore file to prevent temp directory from being indexed by Jellyfin
         if IGNORE_JELLYFIN_INDEXING:
             ignore_path = os.path.join(self.temp_dir, '.ignore')

--- a/config.json
+++ b/config.json
@@ -36,8 +36,7 @@
         ],
         "limit_segment": 0,
         "cleanup_tmp_folder": true,
-        "get_only_link": false,
-        "ignore_jellyfin_indexing": true
+        "get_only_link": false
     },
     "M3U8_CONVERSION": {
         "use_gpu": false,

--- a/config.json
+++ b/config.json
@@ -36,7 +36,8 @@
         ],
         "limit_segment": 0,
         "cleanup_tmp_folder": true,
-        "get_only_link": false
+        "get_only_link": false,
+        "ignore_jellyfin_indexing": true
     },
     "M3U8_CONVERSION": {
         "use_gpu": false,


### PR DESCRIPTION
On HLS Downloader, setup_directories can create .ignore files inside _tmp
resolve  #428 