### PR TITLE
[CONF] Add SERIES_FORMAT

### DIFF
--- a/Conf/config.json
+++ b/Conf/config.json
@@ -13,6 +13,8 @@
         "movie_format": "%(title_name) (%(title_year))",
         "episode_format": "%(episode_name) S%(season)E%(episode)",
         "season_format": "S%(season)",
+        "series_format": "%(series_name)",
+        "season_padding": true,
         "add_siteName": false
     },
     "DOWNLOAD": {

--- a/VibraVid/services/_base/tv_display_manager.py
+++ b/VibraVid/services/_base/tv_display_manager.py
@@ -7,7 +7,7 @@ from typing import List
 from rich.console import Console
 from rich.prompt import Prompt
 
-from VibraVid.utils import config_manager, os_manager
+from VibraVid.utils import config_manager, os_manager, tmdb_client
 from VibraVid.utils.console import TVShowManager
 
 
@@ -16,6 +16,8 @@ console = Console()
 MOVIE_FORMAT = config_manager.config.get('OUTPUT', 'movie_format')
 EPISODE_FORMAT = config_manager.config.get('OUTPUT', 'episode_format')
 SEASON_FORMAT = config_manager.config.get('OUTPUT', 'season_format')
+SERIES_FORMAT = config_manager.config.get('OUTPUT', 'series_format')
+SEASON_PADDING = config_manager.config.get('OUTPUT', 'season_padding')
 
 
 def dynamic_format_number(number_str: str) -> str:
@@ -135,6 +137,37 @@ def map_movie_title(title_name: str, title_year: str = None) -> str:
     return map_movie_temp
 
 
+def map_series_name(series_name: str, series_year: str = None) -> str:
+    """
+    Maps the series name to a specific format using the series_format config.
+
+    Parameters:
+        series_name (str): The name of the series.
+        series_year (str): The release year of the series (optional).
+
+    Returns:
+        str: The formatted series name for folder naming.
+    """
+    map_series_temp = SERIES_FORMAT
+
+    if series_name is not None:
+        map_series_temp = map_series_temp.replace("%(series_name)", os_manager.get_sanitize_file(series_name))
+        map_series_temp = map_series_temp.replace("%(series_slug)", tmdb_client._slugify(series_name))
+
+    if series_year is not None:
+        y = str(series_year).split('-')[0].strip()
+        if y.isdigit() and len(y) == 4:
+            map_series_temp = map_series_temp.replace("%(series_year)", y)
+        else:
+            map_series_temp = map_series_temp.replace("(%(series_year))", "").strip()
+            map_series_temp = map_series_temp.replace("%(series_year)", "").strip()
+    else:
+        map_series_temp = map_series_temp.replace("(%(series_year))", "").strip()
+        map_series_temp = map_series_temp.replace("%(series_year)", "").strip()
+
+    return map_series_temp
+
+
 def map_episode_title(tv_name: str, number_season: int, episode_number: int, episode_name: str) -> str:
     """
     Maps the episode title to a specific format.
@@ -169,6 +202,22 @@ def map_episode_title(tv_name: str, number_season: int, episode_number: int, epi
     return map_episode_temp
 
 
+def format_season_number(season_number: int) -> str:
+    """
+    Formats the season number based on the season_padding config.
+    
+    Parameters:
+        season_number (int): The season number.
+    
+    Returns:
+        str: The formatted season number.
+    """
+    if SEASON_PADDING:
+        return str(season_number).zfill(2)
+    else:
+        return str(season_number)
+
+
 def map_season_name(season_number: int) -> str:
     """
     Maps the season number to a specific format for folder naming.
@@ -182,9 +231,9 @@ def map_season_name(season_number: int) -> str:
     map_season_temp = SEASON_FORMAT
     
     if season_number is not None:
-        map_season_temp = map_season_temp.replace("%(season)", dynamic_format_number(str(season_number)))
+        map_season_temp = map_season_temp.replace("%(season)", format_season_number(season_number))
     else:
-        map_season_temp = map_season_temp.replace("%(season)", dynamic_format_number(str(0)))
+        map_season_temp = map_season_temp.replace("%(season)", format_season_number(0))
 
     return map_season_temp
 

--- a/VibraVid/services/crunchyroll/downloader.py
+++ b/VibraVid/services/crunchyroll/downloader.py
@@ -10,7 +10,7 @@ from rich.prompt import Prompt
 
 from VibraVid.utils import config_manager, os_manager, start_message
 from VibraVid.services._base import site_constants, Entries
-from VibraVid.services._base.tv_display_manager import map_movie_title, map_episode_title, map_season_name
+from VibraVid.services._base.tv_display_manager import map_movie_title, map_episode_title, map_season_name, map_series_name
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 from VibraVid.source.utils.trans_language import resolve_locale
 
@@ -162,8 +162,7 @@ def download_episode(obj_episode, index_season_selected, index_episode_selected,
     Downloads a specific episode from the specified season.
     """
     start_message()
-    client = scrape_serie.client
-    console.print(f"\n[yellow]Download: [red]{site_constants.SITE_NAME} → [cyan]{scrape_serie.series_name} [white]\\ [magenta]{obj_episode.name} ([cyan]S{index_season_selected}E{index_episode_selected}) \n")
+    client = scrape_serie.client    series_folder_name = map_series_name(scrape_serie.series_name, getattr(scrape_serie, 'year', None))    console.print(f"\n[yellow]Download: [red]{site_constants.SITE_NAME} → [cyan]{scrape_serie.series_name} [white]\\ [magenta]{obj_episode.name} ([cyan]S{index_season_selected}E{index_episode_selected}) \n")
 
     # Define filename and path
     title_name = f"{map_episode_title(scrape_serie.series_name, index_season_selected, index_episode_selected, obj_episode.name)}.{extension_output}"

--- a/VibraVid/services/discoveryeu/downloader.py
+++ b/VibraVid/services/discoveryeu/downloader.py
@@ -7,7 +7,7 @@ from rich.prompt import Prompt
 
 from VibraVid.utils import os_manager, config_manager, start_message
 from VibraVid.services._base import site_constants, Entries
-from VibraVid.services._base.tv_display_manager import map_episode_title, map_season_name
+from VibraVid.services._base.tv_display_manager import map_episode_title, map_season_name, map_series_name
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 
 from VibraVid.core.downloader import DASH_Downloader
@@ -27,11 +27,12 @@ def download_episode(obj_episode, index_season_selected, index_episode_selected,
     """
     start_message()
     client = get_client()
+    series_folder_name = map_series_name(scrape_serie.series_name, getattr(scrape_serie, 'year', None))
     console.print(f"\n[yellow]Download: [red]{site_constants.SITE_NAME} [cyan]{scrape_serie.series_name} [white]\\ [magenta]{obj_episode.name} ([cyan]S{index_season_selected}E{index_episode_selected}) \n")
     
     # Define output path
     episode_name = f"{map_episode_title(scrape_serie.series_name, index_season_selected, index_episode_selected, obj_episode.name)}.{extension_output}"
-    episode_path = os_manager.get_sanitize_path(os.path.join(site_constants.SERIES_FOLDER, scrape_serie.series_name, map_season_name(index_season_selected)))
+    episode_path = os_manager.get_sanitize_path(os.path.join(site_constants.SERIES_FOLDER, series_folder_name, map_season_name(index_season_selected)))
     
     # Get playback information using the new client
     playback_info = client.get_playback_info(obj_episode.id)

--- a/VibraVid/services/discoveryus/downloader.py
+++ b/VibraVid/services/discoveryus/downloader.py
@@ -7,7 +7,7 @@ from rich.prompt import Prompt
 
 from VibraVid.utils import os_manager, config_manager, start_message
 from VibraVid.services._base import site_constants, Entries
-from VibraVid.services._base.tv_display_manager import map_episode_title, map_season_name
+from VibraVid.services._base.tv_display_manager import map_episode_title, map_season_name, map_series_name
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 
 from VibraVid.core.downloader import DASH_Downloader
@@ -26,12 +26,13 @@ def download_episode(obj_episode, index_season_selected, index_episode_selected,
     Downloads a specific episode from the specified season.
     """
     start_message()
+    series_folder_name = map_series_name(scrape_serie.series_name, getattr(scrape_serie, 'year', None))
     console.print(f"\n[yellow]Download: [red]{site_constants.SITE_NAME} → [cyan]{scrape_serie.series_name} [white]\\ [magenta]{obj_episode.name} ([cyan]S{index_season_selected}E{index_episode_selected}) \n")
     
     # Define output path
     episode_name = f"{map_episode_title(scrape_serie.series_name, index_season_selected, index_episode_selected, obj_episode.name)}.{extension_output}"
     episode_path = os_manager.get_sanitize_path(
-        os.path.join(site_constants.SERIES_FOLDER, scrape_serie.series_name, map_season_name(index_season_selected))
+        os.path.join(site_constants.SERIES_FOLDER, series_folder_name, map_season_name(index_season_selected))
     )
     
     # Get playback information using video_id

--- a/VibraVid/services/dmax/downloader.py
+++ b/VibraVid/services/dmax/downloader.py
@@ -7,7 +7,7 @@ from rich.prompt import Prompt
 
 from VibraVid.utils import config_manager, start_message
 from VibraVid.services._base import site_constants, Entries
-from VibraVid.services._base.tv_display_manager import map_episode_title, map_season_name
+from VibraVid.services._base.tv_display_manager import map_episode_title, map_season_name, map_series_name
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 
 from VibraVid.core.downloader import HLS_Downloader
@@ -26,11 +26,12 @@ def download_episode(obj_episode, index_season_selected, index_episode_selected,
     Downloads a specific episode from the specified season.
     """
     start_message()
+    series_folder_name = map_series_name(scrape_serie.series_name, getattr(scrape_serie, 'year', None))
     console.print(f"\n[yellow]Download: [red]{site_constants.SITE_NAME} → [cyan]{scrape_serie.series_name} [white]\\ [magenta]{obj_episode.name} ([cyan]S{index_season_selected}E{index_episode_selected}) \n")
 
     # Define filename and path for the downloaded video
     episode_name = f"{map_episode_title(scrape_serie.series_name, index_season_selected, index_episode_selected, obj_episode.name)}.{extension_output}"
-    episode_path = os.path.join(site_constants.SERIES_FOLDER, scrape_serie.series_name, map_season_name(index_season_selected))
+    episode_path = os.path.join(site_constants.SERIES_FOLDER, series_folder_name, map_season_name(index_season_selected))
 
     # Get m3u8 playlist
     bearer_token = get_bearer_token()

--- a/VibraVid/services/foodnetwork/downloader.py
+++ b/VibraVid/services/foodnetwork/downloader.py
@@ -7,7 +7,7 @@ from rich.prompt import Prompt
 
 from VibraVid.utils import config_manager, start_message
 from VibraVid.services._base import site_constants, Entries
-from VibraVid.services._base.tv_display_manager import map_episode_title, map_season_name
+from VibraVid.services._base.tv_display_manager import map_episode_title, map_season_name, map_series_name
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 
 from VibraVid.core.downloader import HLS_Downloader
@@ -26,11 +26,12 @@ def download_episode(obj_episode, index_season_selected, index_episode_selected,
     Downloads a specific episode from the specified season.
     """
     start_message()
+    series_folder_name = map_series_name(scrape_serie.series_name, getattr(scrape_serie, 'year', None))
     console.print(f"\n[yellow]Download: [red]{site_constants.SITE_NAME} → [cyan]{scrape_serie.series_name} [white]\\ [magenta]{obj_episode.name} ([cyan]S{index_season_selected}E{index_episode_selected}) \n")
 
     # Define filename and path for the downloaded video
     episode_name = f"{map_episode_title(scrape_serie.series_name, index_season_selected, index_episode_selected, obj_episode.name)}.{extension_output}"
-    episode_path = os.path.join(site_constants.SERIES_FOLDER, scrape_serie.series_name, map_season_name(index_season_selected))
+    episode_path = os.path.join(site_constants.SERIES_FOLDER, series_folder_name, map_season_name(index_season_selected))
 
     # Get m3u8 playlist
     bearer_token = get_bearer_token()

--- a/VibraVid/services/guardaserie/downloader.py
+++ b/VibraVid/services/guardaserie/downloader.py
@@ -7,7 +7,7 @@ from rich.prompt import Prompt
 
 from VibraVid.utils import config_manager, start_message
 from VibraVid.services._base import site_constants, Entries
-from VibraVid.services._base.tv_display_manager import map_episode_title, map_season_name, dynamic_format_number
+from VibraVid.services._base.tv_display_manager import map_episode_title, map_season_name, dynamic_format_number, map_series_name
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 
 from VibraVid.core.downloader import HLS_Downloader
@@ -28,11 +28,12 @@ def download_episode(obj_episode, index_season_selected, index_episode_selected,
     """
     start_message()
     index_season_selected_formatted = dynamic_format_number(str(index_season_selected))
+    series_folder_name = map_series_name(scrape_serie.tv_name, getattr(scrape_serie, 'year', None))
     console.print(f"\n[yellow]Download: [red]{site_constants.SITE_NAME} → [cyan]{scrape_serie.tv_name} [white]\\ [magenta]{obj_episode.name} ([cyan]S{index_season_selected_formatted}E{index_episode_selected}) \n")
 
     # Define filename and path for the downloaded video
     episode_name = f"{map_episode_title(scrape_serie.tv_name, index_season_selected_formatted, index_episode_selected, obj_episode.name)}.{extension_output}"
-    episode_path = os.path.join(site_constants.SERIES_FOLDER, scrape_serie.tv_name, map_season_name(index_season_selected))
+    episode_path = os.path.join(site_constants.SERIES_FOLDER, series_folder_name, map_season_name(index_season_selected))
 
     # Get the master playlist
     video_source = VideoSource(obj_episode.url)

--- a/VibraVid/services/homegardentv/downloader.py
+++ b/VibraVid/services/homegardentv/downloader.py
@@ -7,7 +7,7 @@ from rich.prompt import Prompt
 
 from VibraVid.utils import config_manager, start_message
 from VibraVid.services._base import site_constants, Entries
-from VibraVid.services._base.tv_display_manager import map_episode_title, map_season_name
+from VibraVid.services._base.tv_display_manager import map_episode_title, map_season_name, map_series_name
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 
 from VibraVid.core.downloader import HLS_Downloader
@@ -26,11 +26,12 @@ def download_episode(obj_episode, index_season_selected, index_episode_selected,
     Downloads a specific episode from the specified season.
     """
     start_message()
+    series_folder_name = map_series_name(scrape_serie.series_name, getattr(scrape_serie, 'year', None))
     console.print(f"\n[yellow]Download: [red]{site_constants.SITE_NAME} → [cyan]{scrape_serie.series_name} [white]\\ [magenta]{obj_episode.name} ([cyan]S{index_season_selected}E{index_episode_selected}) \n")
 
     # Define filename and path for the downloaded video
     episode_name = f"{map_episode_title(scrape_serie.series_name, index_season_selected, index_episode_selected, obj_episode.name)}.{extension_output}"
-    episode_path = os.path.join(site_constants.SERIES_FOLDER, scrape_serie.series_name, map_season_name(index_season_selected))
+    episode_path = os.path.join(site_constants.SERIES_FOLDER, series_folder_name, map_season_name(index_season_selected))
 
     # Get m3u8 playlist
     bearer_token = get_bearer_token()

--- a/VibraVid/services/ipersphera/downloader.py
+++ b/VibraVid/services/ipersphera/downloader.py
@@ -9,6 +9,7 @@ from rich.prompt import Prompt
 from VibraVid.utils import config_manager, start_message
 from VibraVid.utils.http_client import create_client_curl, get_headers
 from VibraVid.services._base import site_constants, Entries
+from VibraVid.services._base.tv_display_manager import map_series_name
 
 from VibraVid.core.downloader import MEGA_Downloader
 
@@ -58,7 +59,8 @@ def download_film(select_title: Entries) -> str:
     if select_title.type == "film":
         title_path = os.path.join(site_constants.MOVIE_FOLDER, str(select_title.name).replace(extension_output, ""))
     else:
-        title_path = os.path.join(site_constants.SERIES_FOLDER, str(select_title.name).replace(extension_output, ""))
+        series_folder_name = map_series_name(select_title.name, select_title.year)
+        title_path = os.path.join(site_constants.SERIES_FOLDER, series_folder_name)
 
     # Download from MEGA
     mega = MEGA_Downloader(

--- a/VibraVid/services/mediasetinfinity/downloader.py
+++ b/VibraVid/services/mediasetinfinity/downloader.py
@@ -11,7 +11,7 @@ from rich.prompt import Prompt
 from VibraVid.utils import os_manager, config_manager, start_message
 from VibraVid.utils.http_client import create_client
 from VibraVid.services._base import site_constants, Entries
-from VibraVid.services._base.tv_display_manager import map_movie_title, map_episode_title, map_season_name
+from VibraVid.services._base.tv_display_manager import map_movie_title, map_episode_title, map_season_name, map_series_name
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 
 from VibraVid.core.downloader import DASH_Downloader
@@ -109,11 +109,12 @@ def download_episode(obj_episode, index_season_selected, index_episode_selected,
     Downloads a specific episode from the specified season.
     """
     start_message()
+    series_folder_name = map_series_name(scrape_serie.series_name, getattr(scrape_serie, 'year', None))
     console.print(f"\n[yellow]Download: [red]{site_constants.SITE_NAME} → [cyan]{scrape_serie.series_name} [white]\\ [magenta]{obj_episode.name} ([cyan]S{index_season_selected}E{index_episode_selected}) \n")
 
     # Define filename and path for the downloaded video
     episode_name = f"{map_episode_title(scrape_serie.series_name, index_season_selected, index_episode_selected, obj_episode.name)}.{extension_output}"
-    episode_path = os_manager.get_sanitize_path(os.path.join(site_constants.SERIES_FOLDER, scrape_serie.series_name, map_season_name(index_season_selected)))
+    episode_path = os_manager.get_sanitize_path(os.path.join(site_constants.SERIES_FOLDER, series_folder_name, map_season_name(index_season_selected)))
 
     # Generate mpd and license URLs
     playback_json = get_playback_url(obj_episode.id)

--- a/VibraVid/services/nove/downloader.py
+++ b/VibraVid/services/nove/downloader.py
@@ -7,7 +7,7 @@ from rich.prompt import Prompt
 
 from VibraVid.utils import config_manager, start_message
 from VibraVid.services._base import site_constants, Entries
-from VibraVid.services._base.tv_display_manager import map_episode_title, map_season_name
+from VibraVid.services._base.tv_display_manager import map_episode_title, map_season_name, map_series_name
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 
 from VibraVid.core.downloader import HLS_Downloader
@@ -26,11 +26,12 @@ def download_episode(obj_episode, index_season_selected, index_episode_selected,
     Downloads a specific episode from the specified season.
     """
     start_message()
+    series_folder_name = map_series_name(scrape_serie.series_name, getattr(scrape_serie, 'year', None))
     console.print(f"\n[yellow]Download: [red]{site_constants.SITE_NAME} → [cyan]{scrape_serie.series_name} [white]\\ [magenta]{obj_episode.name} ([cyan]S{index_season_selected}E{index_episode_selected}) \n")
 
     # Define filename and path for the downloaded video
     episode_name = f"{map_episode_title(scrape_serie.series_name, index_season_selected, index_episode_selected, obj_episode.name)}.{extension_output}"
-    episode_path = os.path.join(site_constants.SERIES_FOLDER, scrape_serie.series_name, map_season_name(index_season_selected))
+    episode_path = os.path.join(site_constants.SERIES_FOLDER, series_folder_name, map_season_name(index_season_selected))
 
     # Get m3u8 playlist
     bearer_token = get_bearer_token()

--- a/VibraVid/services/plutotv/downloader.py
+++ b/VibraVid/services/plutotv/downloader.py
@@ -7,7 +7,7 @@ from rich.prompt import Prompt
 
 from VibraVid.utils import os_manager, config_manager, start_message
 from VibraVid.services._base import site_constants, Entries
-from VibraVid.services._base.tv_display_manager import map_episode_title, map_season_name
+from VibraVid.services._base.tv_display_manager import map_episode_title, map_season_name, map_series_name
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 
 from VibraVid.core.downloader import HLS_Downloader
@@ -26,11 +26,12 @@ def download_episode(obj_episode, index_season_selected, index_episode_selected,
     Downloads a specific episode from the specified season.
     """
     start_message()
+    series_folder_name = map_series_name(scrape_serie.series_name, getattr(scrape_serie, 'year', None))
     console.print(f"\n[yellow]Download: [red]{site_constants.SITE_NAME} → [cyan]{scrape_serie.series_name} [white]\\ [magenta]{obj_episode.name} ([cyan]S{index_season_selected}E{index_episode_selected}) \n")
     
     # Define output path
     episode_name = f"{map_episode_title(scrape_serie.series_name, index_season_selected, index_episode_selected, obj_episode.name)}.{extension_output}"
-    episode_path = os_manager.get_sanitize_path(os.path.join(site_constants.SERIES_FOLDER, scrape_serie.series_name, map_season_name(index_season_selected)))
+    episode_path = os_manager.get_sanitize_path(os.path.join(site_constants.SERIES_FOLDER, series_folder_name, map_season_name(index_season_selected)))
     
     # Get playback information
     content_ids = {

--- a/VibraVid/services/raiplay/downloader.py
+++ b/VibraVid/services/raiplay/downloader.py
@@ -10,7 +10,7 @@ from rich.prompt import Prompt
 from VibraVid.utils import config_manager, start_message
 from VibraVid.utils.http_client import create_client, get_headers, get_userAgent
 from VibraVid.services._base import site_constants, Entries
-from VibraVid.services._base.tv_display_manager import map_movie_title, map_episode_title, map_season_name
+from VibraVid.services._base.tv_display_manager import map_movie_title, map_episode_title, map_season_name, map_series_name
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 
 from VibraVid.core.downloader import DASH_Downloader, HLS_Downloader
@@ -84,11 +84,12 @@ def download_episode(obj_episode, index_season_selected, index_episode_selected,
     Downloads a specific episode from the specified season.
     """
     start_message()
+    series_folder_name = map_series_name(scrape_serie.series_name, getattr(scrape_serie, 'year', None))
     console.print(f"\n[yellow]Download: [red]{site_constants.SITE_NAME} → [cyan]{scrape_serie.series_name} [white]\\ [magenta]{obj_episode.name} ([cyan]S{index_season_selected}E{index_episode_selected}) \n")
 
     # Define filename and path
     episode_name = f"{map_episode_title(scrape_serie.series_name, index_season_selected, index_episode_selected, obj_episode.name)}.{extension_output}"
-    episode_path = os.path.join(site_constants.SERIES_FOLDER, scrape_serie.series_name, map_season_name(index_season_selected))
+    episode_path = os.path.join(site_constants.SERIES_FOLDER, series_folder_name, map_season_name(index_season_selected))
 
     # Get streaming URL
     master_playlist = VideoSource.extract_m3u8_url(obj_episode.url)

--- a/VibraVid/services/realtime/downloader.py
+++ b/VibraVid/services/realtime/downloader.py
@@ -7,7 +7,7 @@ from rich.prompt import Prompt
 
 from VibraVid.utils import config_manager, start_message
 from VibraVid.services._base import site_constants, Entries
-from VibraVid.services._base.tv_display_manager import map_episode_title, map_season_name
+from VibraVid.services._base.tv_display_manager import map_episode_title, map_season_name, map_series_name
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 
 from VibraVid.core.downloader import HLS_Downloader
@@ -26,11 +26,12 @@ def download_episode(obj_episode, index_season_selected, index_episode_selected,
     Downloads a specific episode from the specified season.
     """
     start_message()
+    series_folder_name = map_series_name(scrape_serie.series_name, getattr(scrape_serie, 'year', None))
     console.print(f"\n[yellow]Download: [red]{site_constants.SITE_NAME} → [cyan]{scrape_serie.series_name} [white]\\ [magenta]{obj_episode.name} ([cyan]S{index_season_selected}E{index_episode_selected}) \n")
 
     # Define filename and path for the downloaded video
     episode_name = f"{map_episode_title(scrape_serie.series_name, index_season_selected, index_episode_selected, obj_episode.name)}.{extension_output}"
-    episode_path = os.path.join(site_constants.SERIES_FOLDER, scrape_serie.series_name, map_season_name(index_season_selected))
+    episode_path = os.path.join(site_constants.SERIES_FOLDER, series_folder_name, map_season_name(index_season_selected))
 
     # Get hls url
     bearer_token = get_bearer_token()

--- a/VibraVid/services/streamingcommunity/downloader.py
+++ b/VibraVid/services/streamingcommunity/downloader.py
@@ -7,7 +7,7 @@ from rich.prompt import Prompt
 
 from VibraVid.utils import config_manager, tmdb_client, start_message
 from VibraVid.services._base import site_constants, Entries
-from VibraVid.services._base.tv_display_manager import map_movie_title, map_episode_title, map_season_name
+from VibraVid.services._base.tv_display_manager import map_movie_title, map_episode_title, map_season_name, map_series_name
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 
 from VibraVid.core.downloader import HLS_Downloader
@@ -69,11 +69,12 @@ def download_episode(obj_episode, index_season_selected, index_episode_selected,
     """
     start_message()
     series_display = getattr(scrape_serie, 'series_display_name', None) or scrape_serie.series_name
+    series_folder_name = map_series_name(series_display, getattr(scrape_serie, 'year', None))
     console.print(f"\n[yellow]Download: [red]{site_constants.SITE_NAME} → [cyan]{series_display} [white]\\ [magenta]{obj_episode.name} ([cyan]S{index_season_selected}E{index_episode_selected}) \n")
 
     # Define filename and path for the downloaded video
     episode_name = f"{map_episode_title(series_display, index_season_selected, index_episode_selected, obj_episode.name)}.{extension_output}"
-    episode_path = os.path.join(site_constants.SERIES_FOLDER, series_display, map_season_name(index_season_selected))
+    episode_path = os.path.join(site_constants.SERIES_FOLDER, series_folder_name, map_season_name(index_season_selected))
 
     if use_other_api:
         series_slug = scrape_serie.series_name.lower().replace(' ', '-').replace("'", '')

--- a/VibraVid/services/tubitv/downloader.py
+++ b/VibraVid/services/tubitv/downloader.py
@@ -9,7 +9,7 @@ from rich.prompt import Prompt
 
 from VibraVid.utils import config_manager, start_message
 from VibraVid.services._base import site_constants, Entries
-from VibraVid.services._base.tv_display_manager import map_movie_title, map_episode_title, map_season_name
+from VibraVid.services._base.tv_display_manager import map_movie_title, map_episode_title, map_season_name, map_series_name
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 
 from VibraVid.core.downloader import HLS_Downloader
@@ -76,11 +76,12 @@ def download_episode(obj_episode, index_season_selected, index_episode_selected,
     Downloads a specific episode from the specified season.
     """
     start_message()
+    series_folder_name = map_series_name(scrape_serie.series_name, getattr(scrape_serie, 'year', None))
     console.print(f"\n[yellow]Download: [red]{site_constants.SITE_NAME} → [cyan]{scrape_serie.series_name} [white]\\ [magenta]{obj_episode.name} ([cyan]S{index_season_selected}E{index_episode_selected}) \n")
 
     # Define filename and path for the downloaded video
     episode_name = f"{map_episode_title(scrape_serie.series_name, index_season_selected, index_episode_selected, obj_episode.name)}.{extension_output}"
-    episode_path = os.path.join(site_constants.SERIES_FOLDER, scrape_serie.series_name, map_season_name(index_season_selected))
+    episode_path = os.path.join(site_constants.SERIES_FOLDER, series_folder_name, map_season_name(index_season_selected))
 
     # Get master playlist URL
     try:


### PR DESCRIPTION
config.json: Added "series_format": "%(series_name)" and "season_padding": true
tv_display_manager.py: Added SERIES_FORMAT, SEASON_PADDING, map_series_name() function, and modified map_season_name() to use configurable padding
16 downloader files: Updated to use map_series_name() for series folder names while keeping original names for display and episode titles

Features
Series Format Configuration: Users can set "series_format" to "%(series_name)" (default), "%(series_slug)" for slugified names, or combinations like "%(series_name) (%(series_year))".

Season Padding Control: "season_padding": true (default) produces "S01", "S02"; false produces "S1", "S2".