### PR TITLE
Add Cinezo.net integration + fix guardaserie/mostraguarda

### DIFF
--- a/GUI/searchapp/api/__init__.py
+++ b/GUI/searchapp/api/__init__.py
@@ -25,7 +25,9 @@ _PREFERRED_ORDER = [
     'realtime',
     'homegardentv', 
     'foodnetwork', 
-    'tubitv', 
+    'tubitv',
+    'plutotv',
+    'cinezo',
     'mostraguarda'
 ]
 

--- a/GUI/searchapp/api/cinezo.py
+++ b/GUI/searchapp/api/cinezo.py
@@ -1,0 +1,83 @@
+# Cinezo GUI API wrapper
+
+import importlib
+from typing import List, Optional
+
+from .base import BaseStreamingAPI, Entries, Season, Episode
+
+from VibraVid.services._base.site_loader import get_folder_name
+from VibraVid.services.cinezo.scrapper import GetSerieInfo
+
+
+class CinezoAPI(BaseStreamingAPI):
+
+    def __init__(self):
+        super().__init__()
+        self.site_name  = "cinezo"
+        self._search_fn = None
+
+    def _get_search_fn(self):
+        if self._search_fn is None:
+            module = importlib.import_module(
+                f"VibraVid.{get_folder_name()}.{self.site_name}")
+            self._search_fn = getattr(module, "search")
+        return self._search_fn
+
+    def search(self, query: str) -> List[Entries]:
+        search_fn = self._get_search_fn()
+        database  = search_fn(query, get_onlyDatabase=True)
+        results   = []
+        if database and hasattr(database, 'media_list'):
+            for element in database.media_list:
+                item_dict = element.__dict__.copy() if hasattr(element, '__dict__') else {}
+                results.append(Entries(
+                    id       = item_dict.get('id'),
+                    name     = item_dict.get('name'),
+                    slug     = item_dict.get('slug', ''),
+                    type     = item_dict.get('type'),
+                    url      = item_dict.get('url'),
+                    poster   = item_dict.get('image'),
+                    year     = item_dict.get('year'),
+                    raw_data = item_dict,
+                ))
+        return results
+
+    def get_series_metadata(self, media_item: Entries) -> Optional[List[Season]]:
+        if media_item.is_movie:
+            return None
+
+        scrape_serie = self.get_cached_scraper(media_item)
+        if not scrape_serie:
+            tmdb_id = int(media_item.id or 0)
+            scrape_serie = GetSerieInfo(tmdb_id, media_item.name or '')
+            self.set_cached_scraper(media_item, scrape_serie)
+
+        count = scrape_serie.getNumberSeason()
+        if not count:
+            return None
+
+        seasons = []
+        for s in scrape_serie.seasons_manager.seasons:
+            episodes = [
+                Episode(number=ep.number, name=ep.name, id=ep.id)
+                for ep in s.episodes.episodes
+            ]
+            seasons.append(Season(
+                number   = s.number,
+                episodes = episodes,
+                name     = s.name,
+            ))
+        return seasons if seasons else None
+
+    def start_download(self, media_item: Entries,
+                       season: Optional[str] = None,
+                       episodes: Optional[str] = None) -> bool:
+        search_fn  = self._get_search_fn()
+        selections = None
+        if season or episodes:
+            selections = {'season': season, 'episode': episodes}
+        scrape_serie = self.get_cached_scraper(media_item)
+        search_fn(direct_item=media_item.raw_data,
+                  selections=selections,
+                  scrape_serie=scrape_serie)
+        return True

--- a/VibraVid/services/cinezo/__init__.py
+++ b/VibraVid/services/cinezo/__init__.py
@@ -1,0 +1,92 @@
+# Cinezo.net service
+# Search via TMDB, stream via api.cinezo.net → api.tulnex.com
+
+from urllib.parse import quote_plus
+
+from rich.console import Console
+from rich.prompt import Prompt
+
+from VibraVid.utils import TVShowManager
+from VibraVid.utils.tmdb_client import tmdb_client
+from VibraVid.services._base import site_constants, EntriesManager, Entries
+from VibraVid.services._base.site_search_manager import base_process_search_result, base_search
+
+from .downloader import download_film, download_series
+
+
+indice  = 12
+_useFor = "Film_Serie"
+
+msg              = Prompt()
+console          = Console()
+entries_manager  = EntriesManager()
+table_show_manager = TVShowManager()
+
+_TMDB_IMG = "https://image.tmdb.org/t/p/w500"
+
+
+def title_search(query: str) -> int:
+    entries_manager.clear()
+    table_show_manager.clear()
+
+    q = quote_plus(query)
+
+    # Cerca film
+    movies = tmdb_client._make_request("search/movie", {"query": q, "language": "it"}) or {}
+    for m in movies.get('results', [])[:10]:
+        poster = f"{_TMDB_IMG}{m['poster_path']}" if m.get('poster_path') else None
+        year   = (m.get('release_date') or '')[:4] or None
+        entries_manager.add(Entries(
+            id    = m['id'],
+            name  = m.get('title', ''),
+            type  = 'film',
+            slug  = 'movie',
+            url   = f"https://www.cinezo.net/watch/movie/{m['id']}",
+            image = poster,
+            year  = year,
+        ))
+
+    # Cerca serie TV
+    shows = tmdb_client._make_request("search/tv", {"query": q, "language": "it"}) or {}
+    for s in shows.get('results', [])[:10]:
+        poster = f"{_TMDB_IMG}{s['poster_path']}" if s.get('poster_path') else None
+        year   = (s.get('first_air_date') or '')[:4] or None
+        entries_manager.add(Entries(
+            id    = s['id'],
+            name  = s.get('name', ''),
+            type  = 'tv',
+            slug  = 'tv',
+            url   = f"https://www.cinezo.net/watch/tv/{s['id']}",
+            image = poster,
+            year  = year,
+        ))
+
+    return len(entries_manager)
+
+
+def process_search_result(select_title, selections=None, scrape_serie=None):
+    return base_process_search_result(
+        select_title         = select_title,
+        download_film_func   = download_film,
+        download_series_func = download_series,
+        media_search_manager = entries_manager,
+        table_show_manager   = table_show_manager,
+        selections           = selections,
+        scrape_serie         = scrape_serie,
+    )
+
+
+def search(string_to_search=None, get_onlyDatabase=False, direct_item=None,
+           selections=None, scrape_serie=None):
+    return base_search(
+        title_search_func    = title_search,
+        process_result_func  = process_search_result,
+        media_search_manager = entries_manager,
+        table_show_manager   = table_show_manager,
+        site_name            = site_constants.SITE_NAME,
+        string_to_search     = string_to_search,
+        get_onlyDatabase     = get_onlyDatabase,
+        direct_item          = direct_item,
+        selections           = selections,
+        scrape_serie         = scrape_serie,
+    )

--- a/VibraVid/services/cinezo/client.py
+++ b/VibraVid/services/cinezo/client.py
@@ -1,0 +1,181 @@
+# Cinezo.net client
+# Stream via api.cinezo.net → api.tulnex.com → 4-layer decode → HLS URL
+
+import json
+import base64
+import hashlib
+import logging
+from urllib.parse import urlparse, parse_qs, unquote
+
+from VibraVid.utils.http_client import create_client, get_userAgent
+
+logger = logging.getLogger(__name__)
+
+API_SERVERS_URL = "https://api.cinezo.net/api/servers"
+_servers_cache  = None
+
+
+def _pbkdf2(password: str, salt, iterations: int, length: int, hash_name: str) -> bytes:
+    if isinstance(salt, str):
+        salt = salt.encode('utf-8')
+    return hashlib.pbkdf2_hmac(
+        hash_name.lower().replace('-', ''),
+        password.encode('utf-8'),
+        salt,
+        iterations,
+        dklen=length
+    )
+
+
+def _aes_cbc_decrypt(ciphertext: bytes, key: bytes, iv: bytes) -> bytes:
+    from Cryptodome.Cipher import AES
+    from Cryptodome.Util.Padding import unpad
+    cipher = AES.new(key, AES.MODE_CBC, iv)
+    return unpad(cipher.decrypt(ciphertext), 16)
+
+
+def _b64decode_safe(s: str) -> bytes:
+    pad = 4 - len(s) % 4
+    if pad < 4:
+        s += '=' * pad
+    return base64.b64decode(s)
+
+
+def decode_payload(payload: str) -> str:
+    """
+    Decodes the 4-layer encrypted payload from api.tulnex.com.
+
+    Layer 4 (v): split on '|', base64-decode data part → L3 string
+    Layer 3 (h): AES-CBC decrypt with PBKDF2-SHA512 key
+    Layer 2:     base64-decode → binary string → chars
+    Layer 1:     XOR with PBKDF2-SHA256 key
+    """
+    # L4: split on '|'
+    sep = payload.index('|')
+    data_b64 = payload[sep + 1:]
+    l3_string = _b64decode_safe(data_b64).decode('utf-8')
+
+    # L3: AES-CBC decrypt
+    parts = l3_string.split('.')
+    if len(parts) != 3:
+        raise ValueError(f"L3: expected 3 parts, got {len(parts)}")
+
+    iv_b64, key_material_b64, cipher_b64 = parts
+    iv         = _b64decode_safe(iv_b64)
+    salt       = _b64decode_safe(key_material_b64)
+    aes_key    = _pbkdf2("Sn00pD0g#L3_AES_S3cur3K3y@2025$", salt, 100_000, 32, 'sha512')
+    ciphertext = _b64decode_safe(cipher_b64)
+    intermediate_b64 = _aes_cbc_decrypt(ciphertext, aes_key, iv).decode('utf-8')
+
+    # L2: atob(r).split(" ").map(parseInt(_, 2)).join("")
+    binary_str = _b64decode_safe(intermediate_b64).decode('utf-8', errors='replace')
+    hex_str = ''.join(
+        chr(int(b, 2)) for b in binary_str.split(' ') if b.strip()
+    )
+
+    # L1: XOR with PBKDF2-SHA256 key
+    xor_key  = _pbkdf2("Sn00pD0g#L1_X0R_M4st3rK3y!2025", "xK9!mR2@pL5#nQ8", 50_000, 32, 'sha256')
+    raw_bytes = bytes.fromhex(hex_str)
+    final    = bytes(raw_bytes[i] ^ xor_key[i % len(xor_key)] for i in range(len(raw_bytes)))
+
+    return final.decode('utf-8')
+
+
+def _parse_stream_result(raw: str):
+    """
+    Parse the decoded payload.
+    Returns (m3u8_url, headers_dict).
+    """
+    # Raw might be a JSON string or a proxy URL string
+    try:
+        cleaned = json.loads(raw)
+    except Exception:
+        cleaned = raw.strip().strip('"')
+
+    if isinstance(cleaned, dict):
+        url     = cleaned.get('url') or cleaned.get('stream') or ''
+        headers = cleaned.get('headers') or {}
+    else:
+        url = cleaned
+
+    # If URL is a proxy URL (prxy.tulnex.com/proxy?url=...&headers=...)
+    parsed  = urlparse(url)
+    params  = parse_qs(parsed.query)
+    headers = {}
+
+    if 'url' in params:
+        real_url = unquote(params['url'][0])
+        if 'headers' in params:
+            try:
+                headers = json.loads(unquote(params['headers'][0]))
+            except Exception:
+                pass
+    else:
+        real_url = url
+
+    return real_url, headers
+
+
+def get_servers():
+    """Fetch and cache server list from api.cinezo.net."""
+    global _servers_cache
+    if _servers_cache:
+        return _servers_cache
+    try:
+        r = create_client(headers={'user-agent': get_userAgent(),
+                                   'referer': 'https://www.cinezo.net/'}).get(
+            API_SERVERS_URL, timeout=10)
+        r.raise_for_status()
+        _servers_cache = r.json()
+        return _servers_cache
+    except Exception as e:
+        logger.error(f"[Cinezo] Failed to fetch servers: {e}")
+        return []
+
+
+def get_stream(tmdb_id: int, media_type: str,
+               season: int = None, episode: int = None):
+    """
+    Returns (m3u8_url, headers) for the given TMDB ID.
+    Tries each server until one succeeds.
+
+    media_type: 'movie' or 'tv'
+    """
+    servers = get_servers()
+    api_headers = {'user-agent': get_userAgent(), 'referer': 'https://api.cinezo.net/'}
+
+    for server in servers:
+        try:
+            if media_type == 'movie':
+                url = server.get('movieApiUrl', '').replace('{id}', str(tmdb_id))
+            else:
+                if not season or not episode:
+                    season, episode = 1, 1
+                url = (server.get('tvApiUrl', '')
+                       .replace('{id}', str(tmdb_id))
+                       .replace('{season}', str(season))
+                       .replace('{episode}', str(episode)))
+
+            if not url:
+                continue
+
+            r = create_client(headers=api_headers).get(url, timeout=8)
+            if not r.ok:
+                continue
+
+            data = r.json()
+            if data.get('v') != 4 or not data.get('payload'):
+                continue
+
+            raw = decode_payload(data['payload'])
+            stream_url, stream_headers = _parse_stream_result(raw)
+
+            if stream_url and stream_url.startswith('http'):
+                logger.info(f"[Cinezo] Server '{server.get('name')}' OK: {stream_url[:60]}")
+                return stream_url, stream_headers
+
+        except Exception as e:
+            logger.debug(f"[Cinezo] Server '{server.get('name')}' failed: {e}")
+            continue
+
+    raise RuntimeError(f"[Cinezo] No working server found for tmdb_id={tmdb_id}")

--- a/VibraVid/services/cinezo/downloader.py
+++ b/VibraVid/services/cinezo/downloader.py
@@ -1,0 +1,117 @@
+# Cinezo downloader
+
+import os
+import logging
+
+from rich.console import Console
+
+from VibraVid.utils import config_manager, start_message, os_manager
+from VibraVid.services._base import site_constants, Entries
+from VibraVid.services._base.tv_display_manager import map_movie_path, map_episode_path
+from VibraVid.core.downloader import HLS_Downloader
+from VibraVid.core.ui.tracker import context_tracker
+
+from .client import get_stream
+from .scrapper import GetSerieInfo
+
+
+console = Console()
+logger  = logging.getLogger(__name__)
+extension_output = config_manager.config.get("PROCESS", "extension")
+
+
+def download_film(select_title: Entries):
+    """Download a movie from Cinezo."""
+    start_message()
+    console.print(f"\n[yellow]Download: [red]{site_constants.SITE_NAME} -> [cyan]{select_title.name}\n")
+
+    tmdb_id = getattr(select_title, 'id', None) or getattr(select_title, 'tmdb_id', None)
+    if not tmdb_id:
+        raise ValueError(f"[Cinezo] No TMDB ID for '{select_title.name}'")
+
+    m3u8_url, stream_headers = get_stream(int(tmdb_id), 'movie')
+    console.print(f"[cyan]Stream: {m3u8_url[:70]}...\n")
+
+    path_components, filename = map_movie_path(select_title.name, select_title.year)
+    out_dir = os_manager.get_sanitize_path(
+        os.path.join(site_constants.MOVIE_FOLDER, *path_components)
+        if path_components else site_constants.MOVIE_FOLDER
+    )
+    out_path = os.path.join(out_dir, f"{filename}.{extension_output}")
+
+    return HLS_Downloader(
+        m3u8_url   = m3u8_url,
+        headers    = stream_headers or None,
+        output_path= out_path,
+    ).start()
+
+
+def download_episode(obj_episode, index: int, scrape_serie: GetSerieInfo, season_number: int):
+    """Download a single episode from Cinezo."""
+    start_message()
+    console.print(
+        f"\n[yellow]Download: [red]{site_constants.SITE_NAME} -> "
+        f"[cyan]{scrape_serie.series_name} (S{season_number}E{obj_episode.number})\n"
+    )
+
+    m3u8_url, stream_headers = get_stream(
+        scrape_serie.tmdb_id, 'tv',
+        season=season_number, episode=int(obj_episode.number)
+    )
+    console.print(f"[cyan]Stream: {m3u8_url[:70]}...\n")
+
+    path_components, filename = map_episode_path(
+        series_name    = scrape_serie.series_name,
+        series_year    = None,
+        season_number  = season_number,
+        episode_number = int(obj_episode.number),
+        episode_name   = obj_episode.name,
+    )
+    out_dir  = os_manager.get_sanitize_path(
+        os.path.join(site_constants.SERIES_FOLDER, *path_components))
+    out_path = os.path.join(out_dir, f"{filename}.{extension_output}")
+
+    return HLS_Downloader(
+        m3u8_url   = m3u8_url,
+        headers    = stream_headers or None,
+        output_path= out_path,
+    ).start()
+
+
+def download_series(select_title: Entries, season_selection: str = None,
+                    episode_selection: str = None, scrape_serie: GetSerieInfo = None):
+    """Download selected episodes from Cinezo."""
+    from rich.prompt import Prompt
+    from VibraVid.services._base.tv_display_manager import manage_selection
+
+    start_message()
+
+    tmdb_id = getattr(select_title, 'id', None) or getattr(select_title, 'tmdb_id', None)
+    if scrape_serie is None:
+        scrape_serie = GetSerieInfo(int(tmdb_id), select_title.name)
+
+    scrape_serie.getNumberSeason()
+    console.print(f"\n[green]Serie: [cyan]{select_title.name}")
+
+    if season_selection is None:
+        season_selection = Prompt.ask("\n[cyan]Inserisci numero stagione")
+    season_num = int(season_selection)
+
+    episodes = scrape_serie.getEpisodeSeasons(season_num)
+    if not episodes:
+        console.print(f"[red]Nessun episodio trovato per stagione {season_num}.")
+        return
+
+    console.print(f"\n[green]Episodi disponibili: [red]{len(episodes)}")
+
+    if episode_selection is None:
+        episode_selection = Prompt.ask(
+            "\n[cyan]Inserisci indice episodio, [red]* [cyan]per tutti, [red]1-3 [cyan]per range")
+
+    list_ep = manage_selection(episode_selection, len(episodes))
+    kill = False
+    for i in list_ep:
+        if kill:
+            break
+        ep = episodes[i - 1]
+        _, kill = download_episode(ep, i - 1, scrape_serie, season_num)

--- a/VibraVid/services/cinezo/scrapper.py
+++ b/VibraVid/services/cinezo/scrapper.py
@@ -1,0 +1,59 @@
+# Cinezo series scrapper - uses TMDB for season/episode metadata
+
+import logging
+from typing import List, Optional
+
+from VibraVid.services._base.object import SeasonManager, Season, Episode, EpisodeManager
+from VibraVid.utils.tmdb_client import tmdb_client
+
+logger = logging.getLogger(__name__)
+
+
+class GetSerieInfo:
+    """
+    Fetches season/episode metadata for a Cinezo series via TMDB.
+    """
+
+    def __init__(self, tmdb_id: int, series_name: str):
+        self.tmdb_id     = tmdb_id
+        self.series_name = series_name
+        self.seasons_manager = SeasonManager()
+        self._loaded = False
+
+    def _load(self):
+        if self._loaded:
+            return
+        self._loaded = True
+        try:
+            details = tmdb_client._make_request(f"tv/{self.tmdb_id}",
+                                                {"language": "it"}) or {}
+            for raw_s in details.get('seasons', []):
+                sn = raw_s.get('season_number', 0)
+                if sn == 0:
+                    continue  # skip specials
+
+                ep_count = raw_s.get('episode_count', 0)
+                em = EpisodeManager()
+                for ep_num in range(1, ep_count + 1):
+                    em.add(Episode(
+                        id     = ep_num,
+                        number = ep_num,
+                        name   = f"Episodio {ep_num}",
+                    ))
+
+                s = Season(id=sn, number=sn, name=raw_s.get('name', f"Stagione {sn}"), slug='')
+                s.episodes = em
+                self.seasons_manager.add(s)
+        except Exception as e:
+            logger.error(f"[Cinezo] TMDB series load failed: {e}")
+
+    def getNumberSeason(self) -> int:
+        self._load()
+        return len(self.seasons_manager.seasons)
+
+    def getEpisodeSeasons(self, season_number: int) -> list:
+        self._load()
+        season = self.seasons_manager.get_season_by_number(season_number)
+        if not season:
+            return []
+        return season.episodes.episodes

--- a/VibraVid/services/guardaserie/__init__.py
+++ b/VibraVid/services/guardaserie/__init__.py
@@ -46,13 +46,25 @@ def title_search(query: str) -> int:
     # Create soup and find table
     soup = BeautifulSoup(response.text, "html.parser")
 
-    for serie_div in soup.find_all('div', class_='mlnew'):
+    for serie_div in soup.find_all('div', class_='movie'):
         try:
+            a   = serie_div.find('a')
+            img = serie_div.find('img')
+
+            title_tag = serie_div.find(class_=lambda c: c and 'title' in str(c).lower())
+            name = (title_tag.get_text(strip=True) if title_tag else
+                    a.get('title', '').replace('streaming guardaserie', '').strip() or
+                    a.get_text(strip=True))
+
+            image = (img.get('data-src') or img.get('src', '')) if img else ''
+            if image and image.startswith('/'):
+                image = site_constants.FULL_URL + image
+
             entries_manager.add(Entries(
-                name=serie_div.find('a').get("title").replace("streaming guardaserie", ""),
-                type='tv',
-                url=serie_div.find('a').get("href"),
-                image=f"{site_constants.FULL_URL}/{serie_div.find('img').get('src')}"
+                name  = name,
+                type  = 'tv',
+                url   = a.get('href', ''),
+                image = image,
             ))
 
         except Exception as e:

--- a/VibraVid/services/mostraguarda/__init__.py
+++ b/VibraVid/services/mostraguarda/__init__.py
@@ -52,7 +52,7 @@ def title_search(query: str) -> int:
             path_id=None,
             type='film',
             url='',  # Not needed for download
-            image=movie.get('poster_path'),
+            image=f"https://image.tmdb.org/t/p/w500{movie.get('poster_path')}" if movie.get('poster_path') else None,
             imdb_id=movie.get('imdb_id'),
             year=year
         )


### PR DESCRIPTION
Come funziona:
Cinezo usa ID TMDB. La ricerca avviene tramite TMDB API. Per lo stream, si chiama api.cinezo.net/api/servers che restituisce una lista di ~36 provider, ognuno con un movieApiUrl e tvApiUrl verso api.tulnex.com. Ogni risposta contiene un payload cifrato con 4 layer (base64 custom → AES-CBC PBKDF2-SHA512 → binary string → XOR PBKDF2-SHA256) con chiavi hardcoded nel frontend JS di api.cinezo.net. Il risultato finale è un URL m3u8  scaricabile normalmente via HLS.
Chiavi di decifratura (estratte dal JS di api.cinezo.net):
- L3 AES-CBC: "Sn00pD0g#L3_AES_S3cur3K3y@2025$"
- L1 XOR password: "Sn00pD0g#L1_X0R_M4st3rK3y!2025", salt: "xK9!mR2@pL5#nQ8"
Nota: le chiavi sono nel codice frontend pubblico — cambieranno probabilmente in futuri aggiornamenti del sito.