### PR TITLE
Feature/cinezo integration

### DIFF
--- a/GUI/searchapp/api/__init__.py
+++ b/GUI/searchapp/api/__init__.py
@@ -26,7 +26,6 @@ _PREFERRED_ORDER = [
     'homegardentv', 
     'foodnetwork', 
     'tubitv',
-    'plutotv',
     'cinezo',
     'mostraguarda'
 ]

--- a/GUI/searchapp/api/__init__.py
+++ b/GUI/searchapp/api/__init__.py
@@ -25,7 +25,9 @@ _PREFERRED_ORDER = [
     'realtime',
     'homegardentv', 
     'foodnetwork', 
-    'tubitv', 
+    'tubitv',
+    'plutotv',
+    'cinezo',
     'mostraguarda'
 ]
 

--- a/GUI/searchapp/api/cinezo.py
+++ b/GUI/searchapp/api/cinezo.py
@@ -1,0 +1,83 @@
+# Cinezo GUI API wrapper
+
+import importlib
+from typing import List, Optional
+
+from .base import BaseStreamingAPI, Entries, Season, Episode
+
+from VibraVid.services._base.site_loader import get_folder_name
+from VibraVid.services.cinezo.scrapper import GetSerieInfo
+
+
+class CinezoAPI(BaseStreamingAPI):
+
+    def __init__(self):
+        super().__init__()
+        self.site_name  = "cinezo"
+        self._search_fn = None
+
+    def _get_search_fn(self):
+        if self._search_fn is None:
+            module = importlib.import_module(
+                f"VibraVid.{get_folder_name()}.{self.site_name}")
+            self._search_fn = getattr(module, "search")
+        return self._search_fn
+
+    def search(self, query: str) -> List[Entries]:
+        search_fn = self._get_search_fn()
+        database  = search_fn(query, get_onlyDatabase=True)
+        results   = []
+        if database and hasattr(database, 'media_list'):
+            for element in database.media_list:
+                item_dict = element.__dict__.copy() if hasattr(element, '__dict__') else {}
+                results.append(Entries(
+                    id       = item_dict.get('id'),
+                    name     = item_dict.get('name'),
+                    slug     = item_dict.get('slug', ''),
+                    type     = item_dict.get('type'),
+                    url      = item_dict.get('url'),
+                    poster   = item_dict.get('image'),
+                    year     = item_dict.get('year'),
+                    raw_data = item_dict,
+                ))
+        return results
+
+    def get_series_metadata(self, media_item: Entries) -> Optional[List[Season]]:
+        if media_item.is_movie:
+            return None
+
+        scrape_serie = self.get_cached_scraper(media_item)
+        if not scrape_serie:
+            tmdb_id = int(media_item.id or 0)
+            scrape_serie = GetSerieInfo(tmdb_id, media_item.name or '')
+            self.set_cached_scraper(media_item, scrape_serie)
+
+        count = scrape_serie.getNumberSeason()
+        if not count:
+            return None
+
+        seasons = []
+        for s in scrape_serie.seasons_manager.seasons:
+            episodes = [
+                Episode(number=ep.number, name=ep.name, id=ep.id)
+                for ep in s.episodes.episodes
+            ]
+            seasons.append(Season(
+                number   = s.number,
+                episodes = episodes,
+                name     = s.name,
+            ))
+        return seasons if seasons else None
+
+    def start_download(self, media_item: Entries,
+                       season: Optional[str] = None,
+                       episodes: Optional[str] = None) -> bool:
+        search_fn  = self._get_search_fn()
+        selections = None
+        if season or episodes:
+            selections = {'season': season, 'episode': episodes}
+        scrape_serie = self.get_cached_scraper(media_item)
+        search_fn(direct_item=media_item.raw_data,
+                  selections=selections,
+                  scrape_serie=scrape_serie)
+        return True

--- a/GUI/searchapp/api/cinezo.py
+++ b/GUI/searchapp/api/cinezo.py
@@ -1,4 +1,4 @@
-# Cinezo GUI API wrapper
+# 17.04.26
 
 import importlib
 from typing import List, Optional
@@ -10,7 +10,6 @@ from VibraVid.services.cinezo.scrapper import GetSerieInfo
 
 
 class CinezoAPI(BaseStreamingAPI):
-
     def __init__(self):
         super().__init__()
         self.site_name  = "cinezo"
@@ -69,15 +68,13 @@ class CinezoAPI(BaseStreamingAPI):
             ))
         return seasons if seasons else None
 
-    def start_download(self, media_item: Entries,
-                       season: Optional[str] = None,
-                       episodes: Optional[str] = None) -> bool:
+    def start_download(self, media_item: Entries, season: Optional[str] = None, episodes: Optional[str] = None) -> bool:
         search_fn  = self._get_search_fn()
         selections = None
+        
         if season or episodes:
             selections = {'season': season, 'episode': episodes}
+        
         scrape_serie = self.get_cached_scraper(media_item)
-        search_fn(direct_item=media_item.raw_data,
-                  selections=selections,
-                  scrape_serie=scrape_serie)
+        search_fn(direct_item=media_item.raw_data, selections=selections, scrape_serie=scrape_serie)
         return True

--- a/GUI/searchapp/api/cinezo.py
+++ b/GUI/searchapp/api/cinezo.py
@@ -17,8 +17,7 @@ class CinezoAPI(BaseStreamingAPI):
 
     def _get_search_fn(self):
         if self._search_fn is None:
-            module = importlib.import_module(
-                f"VibraVid.{get_folder_name()}.{self.site_name}")
+            module = importlib.import_module(f"VibraVid.{get_folder_name()}.{self.site_name}")
             self._search_fn = getattr(module, "search")
         return self._search_fn
 
@@ -66,6 +65,7 @@ class CinezoAPI(BaseStreamingAPI):
                 episodes = episodes,
                 name     = s.name,
             ))
+        
         return seasons if seasons else None
 
     def start_download(self, media_item: Entries, season: Optional[str] = None, episodes: Optional[str] = None) -> bool:

--- a/GUI/searchapp/watchlist_auto.py
+++ b/GUI/searchapp/watchlist_auto.py
@@ -17,6 +17,9 @@ from .models import WatchlistItem
 
 DEFAULT_INTERVAL_SECONDS = 14400
 
+_loop_started = False
+_loop_lock    = threading.Lock()
+
 
 def _get_interval_seconds() -> int:
     raw = os.environ.get("WATCHLIST_AUTO_INTERVAL_SECONDS", "")
@@ -152,8 +155,16 @@ def run_watchlist_auto_once(force: bool = True) -> None:
 
 
 def start_watchlist_auto_loop() -> None:
+    global _loop_started
     if not _should_start_loop():
         return
+    # Guard against Django autoreloader calling AppConfig.ready() twice
+    # in the same process, which would start duplicate background threads.
+    with _loop_lock:
+        if _loop_started:
+            print("[WatchlistAuto] Loop already running in this process, skipping duplicate start.")
+            return
+        _loop_started = True
 
     interval_seconds = _get_interval_seconds()
     thread = threading.Thread(

--- a/VibraVid/cli/command/global_search.py
+++ b/VibraVid/cli/command/global_search.py
@@ -184,8 +184,7 @@ def display_consolidated_results(all_media_items, search_terms):
         if has_year:
             entry["Year"] = str(item.get('year', ''))
         manager.add_tv_show(entry)
-
-    manager.display_data(manager.tv_shows)
+    
     return manager
 
 def select_from_consolidated_results(all_media_items, manager: TVShowManager):

--- a/VibraVid/core/source/manual.py
+++ b/VibraVid/core/source/manual.py
@@ -375,16 +375,13 @@ class MediaDownloader(BaseMediaDownloader):
         return f"aud_{lang.split('-')[0]}"
 
     def _make_stream_dir(self, stream, protocol: str) -> Path:
-        proto = protocol.lower()
-        bw = str(stream.bitrate or 0)
-        sid = _safe(stream.id or "", maxlen=24)
-
+        # !!!!!!!!!!!!!! CAN CREATE PROBLEM FOR WIN FILESYSTEM IF EXCEED 260 CHARACTERS !!!!!!!!!!!!!!
         if stream.type == "video":
             res = _safe(stream.resolution or "unknown")
-            name = f"{proto}_video_{res}_{sid}_{bw}"
+            name = f"v_{res}"
         else:
-            lang = _safe(stream.language or "und")
-            name = f"{proto}_audio_{lang}_{sid}_{bw}"
+            lang = _safe((stream.language or "und").lower())
+            name = f"a_{lang}"
 
         d = self._tmp_dir / name
         d.mkdir(parents=True, exist_ok=True)

--- a/VibraVid/core/source/subtitle.py
+++ b/VibraVid/core/source/subtitle.py
@@ -73,7 +73,12 @@ def build_ext_track_label(track: Dict, track_type: str, ext_override: str = None
         flags.append("[CC]")
     if default:
         flags.append("[DEFAULT]")
-    ext = ext_override or ext_from_url(track.get("url", ""), "UNK")
+    
+    # Use track's extension as fallback if provided
+    track_ext = track.get("extension", "UNK").lower().lstrip(".")
+    ext = ext_override or ext_from_url(track.get("url", ""), track_ext)
+    logger.debug(f"Building label for track: lang_raw={lang_raw}, resolved={resolved}, flags={flags}, ext={ext}")
+
     if plain:
         plain_parts: List[str] = [resolved]
         if flags:
@@ -168,14 +173,24 @@ async def download_external_tracks_with_progress(headers: Dict, external_subtitl
     async with create_async_client(headers=headers) as client:
         for track, track_type in all_tasks:
             lang_raw = (track.get("language") or "unknown").strip()
-            fmt: str = ext_from_url(track.get("url", ""), "UNK")
+
+            # Use track's extension as fallback if provided
+            track_ext = track.get("extension", "UNK").lower().lstrip(".")
+            fmt: str = ext_from_url(track.get("url", ""), track_ext)
             base_lang: str
             flag_suffix: str
             base_lang, flag_suffix = normalize_sub_filename(lang_raw, track)
+            logger.debug(f"Prepared to download track: lang_raw={lang_raw}, base_lang={base_lang}, flag_suffix={flag_suffix}, ext={fmt}, url={track.get('url')}")
 
             try:
                 raw_url = track["url"]
                 final_url, fmt = await resolve_url(client, raw_url, track_type)
+
+                # If format is still UNK and track provides extension, use it
+                if fmt == "UNK" and track.get("extension"):
+                    fmt = track.get("extension").lower().lstrip(".")
+                    logger.debug(f"Using track extension for {track_type}: {fmt}")
+
                 if not is_valid_format(fmt, track_type):
                     logger.error(
                         f"Skipping {track_type} with invalid format '{fmt}' for {lang_raw}: {raw_url}"

--- a/VibraVid/services/cinezo/__init__.py
+++ b/VibraVid/services/cinezo/__init__.py
@@ -1,0 +1,92 @@
+# Cinezo.net service
+# Search via TMDB, stream via api.cinezo.net → api.tulnex.com
+
+from urllib.parse import quote_plus
+
+from rich.console import Console
+from rich.prompt import Prompt
+
+from VibraVid.utils import TVShowManager
+from VibraVid.utils.tmdb_client import tmdb_client
+from VibraVid.services._base import site_constants, EntriesManager, Entries
+from VibraVid.services._base.site_search_manager import base_process_search_result, base_search
+
+from .downloader import download_film, download_series
+
+
+indice  = 12
+_useFor = "Film_Serie"
+
+msg              = Prompt()
+console          = Console()
+entries_manager  = EntriesManager()
+table_show_manager = TVShowManager()
+
+_TMDB_IMG = "https://image.tmdb.org/t/p/w500"
+
+
+def title_search(query: str) -> int:
+    entries_manager.clear()
+    table_show_manager.clear()
+
+    q = quote_plus(query)
+
+    # Cerca film
+    movies = tmdb_client._make_request("search/movie", {"query": q, "language": "it"}) or {}
+    for m in movies.get('results', [])[:10]:
+        poster = f"{_TMDB_IMG}{m['poster_path']}" if m.get('poster_path') else None
+        year   = (m.get('release_date') or '')[:4] or None
+        entries_manager.add(Entries(
+            id    = m['id'],
+            name  = m.get('title', ''),
+            type  = 'film',
+            slug  = 'movie',
+            url   = f"https://www.cinezo.net/watch/movie/{m['id']}",
+            image = poster,
+            year  = year,
+        ))
+
+    # Cerca serie TV
+    shows = tmdb_client._make_request("search/tv", {"query": q, "language": "it"}) or {}
+    for s in shows.get('results', [])[:10]:
+        poster = f"{_TMDB_IMG}{s['poster_path']}" if s.get('poster_path') else None
+        year   = (s.get('first_air_date') or '')[:4] or None
+        entries_manager.add(Entries(
+            id    = s['id'],
+            name  = s.get('name', ''),
+            type  = 'tv',
+            slug  = 'tv',
+            url   = f"https://www.cinezo.net/watch/tv/{s['id']}",
+            image = poster,
+            year  = year,
+        ))
+
+    return len(entries_manager)
+
+
+def process_search_result(select_title, selections=None, scrape_serie=None):
+    return base_process_search_result(
+        select_title         = select_title,
+        download_film_func   = download_film,
+        download_series_func = download_series,
+        media_search_manager = entries_manager,
+        table_show_manager   = table_show_manager,
+        selections           = selections,
+        scrape_serie         = scrape_serie,
+    )
+
+
+def search(string_to_search=None, get_onlyDatabase=False, direct_item=None,
+           selections=None, scrape_serie=None):
+    return base_search(
+        title_search_func    = title_search,
+        process_result_func  = process_search_result,
+        media_search_manager = entries_manager,
+        table_show_manager   = table_show_manager,
+        site_name            = site_constants.SITE_NAME,
+        string_to_search     = string_to_search,
+        get_onlyDatabase     = get_onlyDatabase,
+        direct_item          = direct_item,
+        selections           = selections,
+        scrape_serie         = scrape_serie,
+    )

--- a/VibraVid/services/cinezo/__init__.py
+++ b/VibraVid/services/cinezo/__init__.py
@@ -1,5 +1,4 @@
-# Cinezo.net service
-# Search via TMDB, stream via api.cinezo.net → api.tulnex.com
+# 17.04.26
 
 from urllib.parse import quote_plus
 
@@ -17,11 +16,10 @@ from .downloader import download_film, download_series
 indice  = 12
 _useFor = "Film_Serie"
 
-msg              = Prompt()
-console          = Console()
-entries_manager  = EntriesManager()
+msg = Prompt()
+console = Console()
+entries_manager = EntriesManager()
 table_show_manager = TVShowManager()
-
 _TMDB_IMG = "https://image.tmdb.org/t/p/w500"
 
 
@@ -31,7 +29,7 @@ def title_search(query: str) -> int:
 
     q = quote_plus(query)
 
-    # Cerca film
+    # Search film
     movies = tmdb_client._make_request("search/movie", {"query": q, "language": "it"}) or {}
     for m in movies.get('results', [])[:10]:
         poster = f"{_TMDB_IMG}{m['poster_path']}" if m.get('poster_path') else None
@@ -46,7 +44,7 @@ def title_search(query: str) -> int:
             year  = year,
         ))
 
-    # Cerca serie TV
+    # Search tv series
     shows = tmdb_client._make_request("search/tv", {"query": q, "language": "it"}) or {}
     for s in shows.get('results', [])[:10]:
         poster = f"{_TMDB_IMG}{s['poster_path']}" if s.get('poster_path') else None
@@ -63,7 +61,6 @@ def title_search(query: str) -> int:
 
     return len(entries_manager)
 
-
 def process_search_result(select_title, selections=None, scrape_serie=None):
     return base_process_search_result(
         select_title         = select_title,
@@ -75,9 +72,7 @@ def process_search_result(select_title, selections=None, scrape_serie=None):
         scrape_serie         = scrape_serie,
     )
 
-
-def search(string_to_search=None, get_onlyDatabase=False, direct_item=None,
-           selections=None, scrape_serie=None):
+def search(string_to_search=None, get_onlyDatabase=False, direct_item=None, selections=None, scrape_serie=None):
     return base_search(
         title_search_func    = title_search,
         process_result_func  = process_search_result,

--- a/VibraVid/services/cinezo/client.py
+++ b/VibraVid/services/cinezo/client.py
@@ -9,9 +9,12 @@ import threading
 import concurrent.futures
 from urllib.parse import urlparse, parse_qs, unquote
 
+from rich.console import Console
+
 from VibraVid.utils.http_client import create_client, get_userAgent
 
-logger = logging.getLogger(__name__)
+logger  = logging.getLogger(__name__)
+console = Console()
 
 API_SERVERS_URL = "https://api.cinezo.net/api/servers"
 _servers_cache  = None
@@ -137,6 +140,7 @@ def get_servers():
 
 def _try_server(server, tmdb_id, media_type, season, episode, api_headers, found_event):
     """Query a single server. Returns (stream_url, headers) or None."""
+    name = server.get('name', '?')
     if found_event.is_set():
         return None
     try:
@@ -149,25 +153,33 @@ def _try_server(server, tmdb_id, media_type, season, episode, api_headers, found
                    .replace('{episode}', str(episode)))
 
         if not url or found_event.is_set():
+            console.print(f"[yellow][Cinezo] {name}: no URL template")
             return None
 
         r = create_client(headers=api_headers).get(url, timeout=20)
         if not r.ok or found_event.is_set():
+            console.print(f"[yellow][Cinezo] {name}: HTTP {r.status_code}")
             return None
 
         data = r.json()
-        if data.get('v') != 4 or not data.get('payload'):
+        v = data.get('v')
+        if v != 4 or not data.get('payload'):
+            console.print(f"[yellow][Cinezo] {name}: unexpected payload version v={v}, keys={list(data.keys())}")
             return None
 
         raw = decode_payload(data['payload'])
         stream_url, stream_headers = _parse_stream_result(raw)
 
         if stream_url and stream_url.startswith('http'):
-            logger.info(f"[Cinezo] Server '{server.get('name')}' OK: {stream_url[:60]}")
+            console.print(f"[green][Cinezo] {name}: OK")
+            logger.info(f"[Cinezo] Server '{name}' OK: {stream_url[:60]}")
             return stream_url, stream_headers
 
+        console.print(f"[yellow][Cinezo] {name}: decoded but no valid URL → {str(stream_url)[:80]}")
+
     except Exception as e:
-        logger.debug(f"[Cinezo] Server '{server.get('name')}' failed: {e}")
+        console.print(f"[red][Cinezo] {name}: exception → {e}")
+        logger.debug(f"[Cinezo] Server '{name}' failed: {e}", exc_info=True)
     return None
 
 

--- a/VibraVid/services/cinezo/client.py
+++ b/VibraVid/services/cinezo/client.py
@@ -88,25 +88,41 @@ def decode_payload(payload: str) -> str:
 
 def _parse_stream_result(raw: str):
     """
-    Parse the decoded payload.
+    Parse the decoded payload. Handles three formats:
+      1. JSON string  → direct or proxy URL
+      2. {"url": ..., "headers": ...}  → direct/proxy URL + headers
+      3. {"server": ..., "streams": [{...}]}  → extract first stream entry
     Returns (m3u8_url, headers_dict).
     """
-    # Raw might be a JSON string or a proxy URL string
     try:
         cleaned = json.loads(raw)
     except Exception:
         cleaned = raw.strip().strip('"')
 
-    if isinstance(cleaned, dict):
+    headers = {}
+
+    if isinstance(cleaned, dict) and 'streams' in cleaned:
+        # Format 3: {"server": "...", "streams": [...]}
+        streams = cleaned.get('streams') or []
+        if not streams:
+            return '', {}
+        first = streams[0]
+        if isinstance(first, dict):
+            url     = first.get('url') or first.get('stream') or ''
+            headers = first.get('headers') or {}
+        else:
+            url = str(first) if first else ''
+    elif isinstance(cleaned, dict):
+        # Format 2: {"url": ..., "headers": ...}
         url     = cleaned.get('url') or cleaned.get('stream') or ''
         headers = cleaned.get('headers') or {}
     else:
-        url = cleaned
+        # Format 1: plain string
+        url = cleaned or ''
 
-    # If URL is a proxy URL (prxy.tulnex.com/proxy?url=...&headers=...)
-    parsed  = urlparse(url)
-    params  = parse_qs(parsed.query)
-    headers = {}
+    # Unwrap proxy URL: prxy.tulnex.com/proxy?url=...&headers=...
+    parsed = urlparse(url)
+    params = parse_qs(parsed.query)
 
     if 'url' in params:
         real_url = unquote(params['url'][0])
@@ -178,7 +194,8 @@ def _try_server(server, tmdb_id, media_type, season, episode, api_headers, found
         console.print(f"[yellow][Cinezo] {name}: decoded but no valid URL → {str(stream_url)[:80]}")
 
     except Exception as e:
-        console.print(f"[red][Cinezo] {name}: exception → {e}")
+        import traceback
+        console.print(f"[red][Cinezo] {name}: exception → {e}\n{traceback.format_exc()}")
         logger.debug(f"[Cinezo] Server '{name}' failed: {e}", exc_info=True)
     return None
 

--- a/VibraVid/services/cinezo/client.py
+++ b/VibraVid/services/cinezo/client.py
@@ -5,6 +5,8 @@ import json
 import base64
 import hashlib
 import logging
+import threading
+import concurrent.futures
 from urllib.parse import urlparse, parse_qs, unquote
 
 from VibraVid.utils.http_client import create_client, get_userAgent
@@ -133,49 +135,70 @@ def get_servers():
         return []
 
 
+def _try_server(server, tmdb_id, media_type, season, episode, api_headers, found_event):
+    """Query a single server. Returns (stream_url, headers) or None."""
+    if found_event.is_set():
+        return None
+    try:
+        if media_type == 'movie':
+            url = server.get('movieApiUrl', '').replace('{id}', str(tmdb_id))
+        else:
+            url = (server.get('tvApiUrl', '')
+                   .replace('{id}', str(tmdb_id))
+                   .replace('{season}', str(season))
+                   .replace('{episode}', str(episode)))
+
+        if not url or found_event.is_set():
+            return None
+
+        r = create_client(headers=api_headers).get(url, timeout=20)
+        if not r.ok or found_event.is_set():
+            return None
+
+        data = r.json()
+        if data.get('v') != 4 or not data.get('payload'):
+            return None
+
+        raw = decode_payload(data['payload'])
+        stream_url, stream_headers = _parse_stream_result(raw)
+
+        if stream_url and stream_url.startswith('http'):
+            logger.info(f"[Cinezo] Server '{server.get('name')}' OK: {stream_url[:60]}")
+            return stream_url, stream_headers
+
+    except Exception as e:
+        logger.debug(f"[Cinezo] Server '{server.get('name')}' failed: {e}")
+    return None
+
+
 def get_stream(tmdb_id: int, media_type: str,
                season: int = None, episode: int = None):
     """
     Returns (m3u8_url, headers) for the given TMDB ID.
-    Tries each server until one succeeds.
+    Queries all servers in parallel and returns the first successful result.
 
     media_type: 'movie' or 'tv'
     """
     servers = get_servers()
+    if not servers:
+        raise RuntimeError(f"[Cinezo] No servers available for tmdb_id={tmdb_id}")
+
     api_headers = {'user-agent': get_userAgent(), 'referer': 'https://api.cinezo.net/'}
+    if media_type == 'tv' and (not season or not episode):
+        season, episode = 1, 1
 
-    for server in servers:
-        try:
-            if media_type == 'movie':
-                url = server.get('movieApiUrl', '').replace('{id}', str(tmdb_id))
-            else:
-                if not season or not episode:
-                    season, episode = 1, 1
-                url = (server.get('tvApiUrl', '')
-                       .replace('{id}', str(tmdb_id))
-                       .replace('{season}', str(season))
-                       .replace('{episode}', str(episode)))
+    found_event = threading.Event()
 
-            if not url:
-                continue
-
-            r = create_client(headers=api_headers).get(url, timeout=20)
-            if not r.ok:
-                continue
-
-            data = r.json()
-            if data.get('v') != 4 or not data.get('payload'):
-                continue
-
-            raw = decode_payload(data['payload'])
-            stream_url, stream_headers = _parse_stream_result(raw)
-
-            if stream_url and stream_url.startswith('http'):
-                logger.info(f"[Cinezo] Server '{server.get('name')}' OK: {stream_url[:60]}")
-                return stream_url, stream_headers
-
-        except Exception as e:
-            logger.debug(f"[Cinezo] Server '{server.get('name')}' failed: {e}")
-            continue
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(servers)) as executor:
+        futures = {
+            executor.submit(_try_server, server, tmdb_id, media_type,
+                            season, episode, api_headers, found_event): server
+            for server in servers
+        }
+        for future in concurrent.futures.as_completed(futures):
+            result = future.result()
+            if result is not None:
+                found_event.set()
+                return result
 
     raise RuntimeError(f"[Cinezo] No working server found for tmdb_id={tmdb_id}")

--- a/VibraVid/services/cinezo/client.py
+++ b/VibraVid/services/cinezo/client.py
@@ -159,7 +159,7 @@ def get_stream(tmdb_id: int, media_type: str,
             if not url:
                 continue
 
-            r = create_client(headers=api_headers).get(url, timeout=8)
+            r = create_client(headers=api_headers).get(url, timeout=20)
             if not r.ok:
                 continue
 

--- a/VibraVid/services/cinezo/client.py
+++ b/VibraVid/services/cinezo/client.py
@@ -1,5 +1,4 @@
-# Cinezo.net client
-# Stream via api.cinezo.net → api.tulnex.com → 4-layer decode → HLS URL
+# 17.04.26
 
 import json
 import base64
@@ -23,13 +22,8 @@ _servers_cache  = None
 def _pbkdf2(password: str, salt, iterations: int, length: int, hash_name: str) -> bytes:
     if isinstance(salt, str):
         salt = salt.encode('utf-8')
-    return hashlib.pbkdf2_hmac(
-        hash_name.lower().replace('-', ''),
-        password.encode('utf-8'),
-        salt,
-        iterations,
-        dklen=length
-    )
+    
+    return hashlib.pbkdf2_hmac(hash_name.lower().replace('-', ''), password.encode('utf-8'), salt, iterations, dklen=length)
 
 
 def _aes_cbc_decrypt(ciphertext: bytes, key: bytes, iv: bytes) -> bytes:
@@ -143,9 +137,7 @@ def get_servers():
     if _servers_cache:
         return _servers_cache
     try:
-        r = create_client(headers={'user-agent': get_userAgent(),
-                                   'referer': 'https://www.cinezo.net/'}).get(
-            API_SERVERS_URL, timeout=10)
+        r = create_client(headers={'user-agent': get_userAgent(), 'referer': 'https://www.cinezo.net/'}).get(API_SERVERS_URL)
         r.raise_for_status()
         _servers_cache = r.json()
         return _servers_cache
@@ -163,10 +155,7 @@ def _try_server(server, tmdb_id, media_type, season, episode, api_headers, found
         if media_type == 'movie':
             url = server.get('movieApiUrl', '').replace('{id}', str(tmdb_id))
         else:
-            url = (server.get('tvApiUrl', '')
-                   .replace('{id}', str(tmdb_id))
-                   .replace('{season}', str(season))
-                   .replace('{episode}', str(episode)))
+            url = (server.get('tvApiUrl', '').replace('{id}', str(tmdb_id)).replace('{season}', str(season)).replace('{episode}', str(episode)))
 
         if not url or found_event.is_set():
             console.print(f"[yellow][Cinezo] {name}: no URL template")
@@ -200,8 +189,7 @@ def _try_server(server, tmdb_id, media_type, season, episode, api_headers, found
     return None
 
 
-def get_stream(tmdb_id: int, media_type: str,
-               season: int = None, episode: int = None):
+def get_stream(tmdb_id: int, media_type: str, season: int = None, episode: int = None):
     """
     Returns (m3u8_url, headers) for the given TMDB ID.
     Queries all servers in parallel and returns the first successful result.
@@ -220,8 +208,7 @@ def get_stream(tmdb_id: int, media_type: str,
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=len(servers)) as executor:
         futures = {
-            executor.submit(_try_server, server, tmdb_id, media_type,
-                            season, episode, api_headers, found_event): server
+            executor.submit(_try_server, server, tmdb_id, media_type, season, episode, api_headers, found_event): server
             for server in servers
         }
         for future in concurrent.futures.as_completed(futures):

--- a/VibraVid/services/cinezo/client.py
+++ b/VibraVid/services/cinezo/client.py
@@ -80,38 +80,58 @@ def decode_payload(payload: str) -> str:
     return final.decode('utf-8')
 
 
+def _subs_to_tracks(subs) -> list:
+    """Convert API subtitle list to other_tracks format for HLS_Downloader."""
+    tracks = []
+    for s in (subs or []):
+        if not isinstance(s, dict) or not s.get('url'):
+            continue
+        tracks.append({
+            "type":      "subtitle",
+            "language":  s.get("language") or "und",
+            "name":      s.get("display") or s.get("name") or s.get("language") or "Subtitle",
+            "url":       s["url"],
+            "extension": "vtt",
+        })
+    return tracks
+
+
 def _parse_stream_result(raw: str):
     """
     Parse the decoded payload. Handles three formats:
       1. JSON string  → direct or proxy URL
-      2. {"url": ..., "headers": ...}  → direct/proxy URL + headers
-      3. {"server": ..., "streams": [{...}]}  → extract first stream entry
-    Returns (m3u8_url, headers_dict).
+      2. {"url": ..., "headers": ..., "subtitles": [...]}
+      3. {"server": ..., "streams": [{...}], "subtitles": [...]}
+    Returns (m3u8_url, headers_dict, subtitle_tracks).
     """
     try:
         cleaned = json.loads(raw)
     except Exception:
         cleaned = raw.strip().strip('"')
 
-    headers = {}
+    headers  = {}
+    raw_subs = []
 
     if isinstance(cleaned, dict) and 'streams' in cleaned:
-        # Format 3: {"server": "...", "streams": [...]}
-        streams = cleaned.get('streams') or []
+        # Format 3: {"server": "...", "streams": [...], "subtitles": [...]}
+        streams  = cleaned.get('streams') or []
+        raw_subs = cleaned.get('subtitles') or []
         if not streams:
-            return '', {}
+            return '', {}, []
         first = streams[0]
         if isinstance(first, dict):
-            url     = first.get('url') or first.get('stream') or ''
-            headers = first.get('headers') or {}
+            url      = first.get('url') or first.get('stream') or ''
+            headers  = first.get('headers') or {}
+            raw_subs = raw_subs or first.get('subtitles') or []
         else:
             url = str(first) if first else ''
     elif isinstance(cleaned, dict):
-        # Format 2: {"url": ..., "headers": ...}
-        url     = cleaned.get('url') or cleaned.get('stream') or ''
-        headers = cleaned.get('headers') or {}
+        # Format 2: {"url": ..., "headers": ..., "subtitles": [...]}
+        url      = cleaned.get('url') or cleaned.get('stream') or ''
+        headers  = cleaned.get('headers') or {}
+        raw_subs = cleaned.get('subtitles') or []
     else:
-        # Format 1: plain string
+        # Format 1: plain string — no subtitles
         url = cleaned or ''
 
     # Unwrap proxy URL: prxy.tulnex.com/proxy?url=...&headers=...
@@ -128,7 +148,7 @@ def _parse_stream_result(raw: str):
     else:
         real_url = url
 
-    return real_url, headers
+    return real_url, headers, _subs_to_tracks(raw_subs)
 
 
 def get_servers():
@@ -173,12 +193,13 @@ def _try_server(server, tmdb_id, media_type, season, episode, api_headers, found
             return None
 
         raw = decode_payload(data['payload'])
-        stream_url, stream_headers = _parse_stream_result(raw)
+        stream_url, stream_headers, subtitle_tracks = _parse_stream_result(raw)
 
         if stream_url and stream_url.startswith('http'):
-            console.print(f"[green][Cinezo] {name}: OK")
+            sub_info = f", {len(subtitle_tracks)} sub(s)" if subtitle_tracks else ""
+            console.print(f"[green][Cinezo] {name}: OK{sub_info}")
             logger.info(f"[Cinezo] Server '{name}' OK: {stream_url[:60]}")
-            return stream_url, stream_headers
+            return stream_url, stream_headers, subtitle_tracks
 
         console.print(f"[yellow][Cinezo] {name}: decoded but no valid URL → {str(stream_url)[:80]}")
 
@@ -215,6 +236,6 @@ def get_stream(tmdb_id: int, media_type: str, season: int = None, episode: int =
             result = future.result()
             if result is not None:
                 found_event.set()
-                return result
+                return result  # (stream_url, headers, subtitle_tracks)
 
     raise RuntimeError(f"[Cinezo] No working server found for tmdb_id={tmdb_id}")

--- a/VibraVid/services/cinezo/client.py
+++ b/VibraVid/services/cinezo/client.py
@@ -1,0 +1,181 @@
+# Cinezo.net client
+# Stream via api.cinezo.net → api.tulnex.com → 4-layer decode → HLS URL
+
+import json
+import base64
+import hashlib
+import logging
+from urllib.parse import urlparse, parse_qs, unquote
+
+from VibraVid.utils.http_client import create_client, get_userAgent
+
+logger = logging.getLogger(__name__)
+
+API_SERVERS_URL = "https://api.cinezo.net/api/servers"
+_servers_cache  = None
+
+
+def _pbkdf2(password: str, salt, iterations: int, length: int, hash_name: str) -> bytes:
+    if isinstance(salt, str):
+        salt = salt.encode('utf-8')
+    return hashlib.pbkdf2_hmac(
+        hash_name.lower().replace('-', ''),
+        password.encode('utf-8'),
+        salt,
+        iterations,
+        dklen=length
+    )
+
+
+def _aes_cbc_decrypt(ciphertext: bytes, key: bytes, iv: bytes) -> bytes:
+    from Cryptodome.Cipher import AES
+    from Cryptodome.Util.Padding import unpad
+    cipher = AES.new(key, AES.MODE_CBC, iv)
+    return unpad(cipher.decrypt(ciphertext), 16)
+
+
+def _b64decode_safe(s: str) -> bytes:
+    pad = 4 - len(s) % 4
+    if pad < 4:
+        s += '=' * pad
+    return base64.b64decode(s)
+
+
+def decode_payload(payload: str) -> str:
+    """
+    Decodes the 4-layer encrypted payload from api.tulnex.com.
+
+    Layer 4 (v): split on '|', base64-decode data part → L3 string
+    Layer 3 (h): AES-CBC decrypt with PBKDF2-SHA512 key
+    Layer 2:     base64-decode → binary string → chars
+    Layer 1:     XOR with PBKDF2-SHA256 key
+    """
+    # L4: split on '|'
+    sep = payload.index('|')
+    data_b64 = payload[sep + 1:]
+    l3_string = _b64decode_safe(data_b64).decode('utf-8')
+
+    # L3: AES-CBC decrypt
+    parts = l3_string.split('.')
+    if len(parts) != 3:
+        raise ValueError(f"L3: expected 3 parts, got {len(parts)}")
+
+    iv_b64, key_material_b64, cipher_b64 = parts
+    iv         = _b64decode_safe(iv_b64)
+    salt       = _b64decode_safe(key_material_b64)
+    aes_key    = _pbkdf2("Sn00pD0g#L3_AES_S3cur3K3y@2025$", salt, 100_000, 32, 'sha512')
+    ciphertext = _b64decode_safe(cipher_b64)
+    intermediate_b64 = _aes_cbc_decrypt(ciphertext, aes_key, iv).decode('utf-8')
+
+    # L2: atob(r).split(" ").map(parseInt(_, 2)).join("")
+    binary_str = _b64decode_safe(intermediate_b64).decode('utf-8', errors='replace')
+    hex_str = ''.join(
+        chr(int(b, 2)) for b in binary_str.split(' ') if b.strip()
+    )
+
+    # L1: XOR with PBKDF2-SHA256 key
+    xor_key  = _pbkdf2("Sn00pD0g#L1_X0R_M4st3rK3y!2025", "xK9!mR2@pL5#nQ8", 50_000, 32, 'sha256')
+    raw_bytes = bytes.fromhex(hex_str)
+    final    = bytes(raw_bytes[i] ^ xor_key[i % len(xor_key)] for i in range(len(raw_bytes)))
+
+    return final.decode('utf-8')
+
+
+def _parse_stream_result(raw: str):
+    """
+    Parse the decoded payload.
+    Returns (m3u8_url, headers_dict).
+    """
+    # Raw might be a JSON string or a proxy URL string
+    try:
+        cleaned = json.loads(raw)
+    except Exception:
+        cleaned = raw.strip().strip('"')
+
+    if isinstance(cleaned, dict):
+        url     = cleaned.get('url') or cleaned.get('stream') or ''
+        headers = cleaned.get('headers') or {}
+    else:
+        url = cleaned
+
+    # If URL is a proxy URL (prxy.tulnex.com/proxy?url=...&headers=...)
+    parsed  = urlparse(url)
+    params  = parse_qs(parsed.query)
+    headers = {}
+
+    if 'url' in params:
+        real_url = unquote(params['url'][0])
+        if 'headers' in params:
+            try:
+                headers = json.loads(unquote(params['headers'][0]))
+            except Exception:
+                pass
+    else:
+        real_url = url
+
+    return real_url, headers
+
+
+def get_servers():
+    """Fetch and cache server list from api.cinezo.net."""
+    global _servers_cache
+    if _servers_cache:
+        return _servers_cache
+    try:
+        r = create_client(headers={'user-agent': get_userAgent(),
+                                   'referer': 'https://www.cinezo.net/'}).get(
+            API_SERVERS_URL, timeout=10)
+        r.raise_for_status()
+        _servers_cache = r.json()
+        return _servers_cache
+    except Exception as e:
+        logger.error(f"[Cinezo] Failed to fetch servers: {e}")
+        return []
+
+
+def get_stream(tmdb_id: int, media_type: str,
+               season: int = None, episode: int = None):
+    """
+    Returns (m3u8_url, headers) for the given TMDB ID.
+    Tries each server until one succeeds.
+
+    media_type: 'movie' or 'tv'
+    """
+    servers = get_servers()
+    api_headers = {'user-agent': get_userAgent(), 'referer': 'https://api.cinezo.net/'}
+
+    for server in servers:
+        try:
+            if media_type == 'movie':
+                url = server.get('movieApiUrl', '').replace('{id}', str(tmdb_id))
+            else:
+                if not season or not episode:
+                    season, episode = 1, 1
+                url = (server.get('tvApiUrl', '')
+                       .replace('{id}', str(tmdb_id))
+                       .replace('{season}', str(season))
+                       .replace('{episode}', str(episode)))
+
+            if not url:
+                continue
+
+            r = create_client(headers=api_headers).get(url, timeout=8)
+            if not r.ok:
+                continue
+
+            data = r.json()
+            if data.get('v') != 4 or not data.get('payload'):
+                continue
+
+            raw = decode_payload(data['payload'])
+            stream_url, stream_headers = _parse_stream_result(raw)
+
+            if stream_url and stream_url.startswith('http'):
+                logger.info(f"[Cinezo] Server '{server.get('name')}' OK: {stream_url[:60]}")
+                return stream_url, stream_headers
+
+        except Exception as e:
+            logger.debug(f"[Cinezo] Server '{server.get('name')}' failed: {e}")
+            continue
+
+    raise RuntimeError(f"[Cinezo] No working server found for tmdb_id={tmdb_id}")

--- a/VibraVid/services/cinezo/downloader.py
+++ b/VibraVid/services/cinezo/downloader.py
@@ -1,0 +1,117 @@
+# Cinezo downloader
+
+import os
+import logging
+
+from rich.console import Console
+
+from VibraVid.utils import config_manager, start_message, os_manager
+from VibraVid.services._base import site_constants, Entries
+from VibraVid.services._base.tv_display_manager import map_movie_path, map_episode_path
+from VibraVid.core.downloader import HLS_Downloader
+from VibraVid.core.ui.tracker import context_tracker
+
+from .client import get_stream
+from .scrapper import GetSerieInfo
+
+
+console = Console()
+logger  = logging.getLogger(__name__)
+extension_output = config_manager.config.get("PROCESS", "extension")
+
+
+def download_film(select_title: Entries):
+    """Download a movie from Cinezo."""
+    start_message()
+    console.print(f"\n[yellow]Download: [red]{site_constants.SITE_NAME} -> [cyan]{select_title.name}\n")
+
+    tmdb_id = getattr(select_title, 'id', None) or getattr(select_title, 'tmdb_id', None)
+    if not tmdb_id:
+        raise ValueError(f"[Cinezo] No TMDB ID for '{select_title.name}'")
+
+    m3u8_url, stream_headers = get_stream(int(tmdb_id), 'movie')
+    console.print(f"[cyan]Stream: {m3u8_url[:70]}...\n")
+
+    path_components, filename = map_movie_path(select_title.name, select_title.year)
+    out_dir = os_manager.get_sanitize_path(
+        os.path.join(site_constants.MOVIE_FOLDER, *path_components)
+        if path_components else site_constants.MOVIE_FOLDER
+    )
+    out_path = os.path.join(out_dir, f"{filename}.{extension_output}")
+
+    return HLS_Downloader(
+        m3u8_url   = m3u8_url,
+        headers    = stream_headers or None,
+        output_path= out_path,
+    ).start()
+
+
+def download_episode(obj_episode, index: int, scrape_serie: GetSerieInfo, season_number: int):
+    """Download a single episode from Cinezo."""
+    start_message()
+    console.print(
+        f"\n[yellow]Download: [red]{site_constants.SITE_NAME} -> "
+        f"[cyan]{scrape_serie.series_name} (S{season_number}E{obj_episode.number})\n"
+    )
+
+    m3u8_url, stream_headers = get_stream(
+        scrape_serie.tmdb_id, 'tv',
+        season=season_number, episode=int(obj_episode.number)
+    )
+    console.print(f"[cyan]Stream: {m3u8_url[:70]}...\n")
+
+    path_components, filename = map_episode_path(
+        series_name    = scrape_serie.series_name,
+        series_year    = None,
+        season_number  = season_number,
+        episode_number = int(obj_episode.number),
+        episode_name   = obj_episode.name,
+    )
+    out_dir  = os_manager.get_sanitize_path(
+        os.path.join(site_constants.SERIES_FOLDER, *path_components))
+    out_path = os.path.join(out_dir, f"{filename}.{extension_output}")
+
+    return HLS_Downloader(
+        m3u8_url   = m3u8_url,
+        headers    = stream_headers or None,
+        output_path= out_path,
+    ).start()
+
+
+def download_series(select_title: Entries, season_selection: str = None,
+                    episode_selection: str = None, scrape_serie: GetSerieInfo = None):
+    """Download selected episodes from Cinezo."""
+    from rich.prompt import Prompt
+    from VibraVid.services._base.tv_display_manager import manage_selection
+
+    start_message()
+
+    tmdb_id = getattr(select_title, 'id', None) or getattr(select_title, 'tmdb_id', None)
+    if scrape_serie is None:
+        scrape_serie = GetSerieInfo(int(tmdb_id), select_title.name)
+
+    scrape_serie.getNumberSeason()
+    console.print(f"\n[green]Serie: [cyan]{select_title.name}")
+
+    if season_selection is None:
+        season_selection = Prompt.ask("\n[cyan]Inserisci numero stagione")
+    season_num = int(season_selection)
+
+    episodes = scrape_serie.getEpisodeSeasons(season_num)
+    if not episodes:
+        console.print(f"[red]Nessun episodio trovato per stagione {season_num}.")
+        return
+
+    console.print(f"\n[green]Episodi disponibili: [red]{len(episodes)}")
+
+    if episode_selection is None:
+        episode_selection = Prompt.ask(
+            "\n[cyan]Inserisci indice episodio, [red]* [cyan]per tutti, [red]1-3 [cyan]per range")
+
+    list_ep = manage_selection(episode_selection, len(episodes))
+    kill = False
+    for i in list_ep:
+        if kill:
+            break
+        ep = episodes[i - 1]
+        _, kill = download_episode(ep, i - 1, scrape_serie, season_num)

--- a/VibraVid/services/cinezo/downloader.py
+++ b/VibraVid/services/cinezo/downloader.py
@@ -62,7 +62,7 @@ def download_episode(obj_episode, index: int, scrape_serie: GetSerieInfo, season
 
     path_components, filename = map_episode_path(
         series_name    = scrape_serie.series_name,
-        series_year    = None,
+        series_year    = scrape_serie.series_year,
         season_number  = season_number,
         episode_number = int(obj_episode.number),
         episode_name   = obj_episode.name,

--- a/VibraVid/services/cinezo/downloader.py
+++ b/VibraVid/services/cinezo/downloader.py
@@ -29,7 +29,7 @@ def download_film(select_title: Entries):
     if not tmdb_id:
         raise ValueError(f"[Cinezo] No TMDB ID for '{select_title.name}'")
 
-    m3u8_url, stream_headers = get_stream(int(tmdb_id), 'movie')
+    m3u8_url, stream_headers, subtitle_tracks = get_stream(int(tmdb_id), 'movie')
     console.print(f"[cyan]Stream: {m3u8_url[:70]}...\n")
 
     path_components, filename = map_movie_path(select_title.name, select_title.year)
@@ -40,9 +40,10 @@ def download_film(select_title: Entries):
     out_path = os.path.join(out_dir, f"{filename}.{extension_output}")
 
     return HLS_Downloader(
-        m3u8_url   = m3u8_url,
-        headers    = stream_headers or None,
-        output_path= out_path,
+        m3u8_url     = m3u8_url,
+        headers      = stream_headers or None,
+        output_path  = out_path,
+        other_tracks = subtitle_tracks or None,
     ).start()
 
 
@@ -54,7 +55,7 @@ def download_episode(obj_episode, index: int, scrape_serie: GetSerieInfo, season
         f"[cyan]{scrape_serie.series_name} (S{season_number}E{obj_episode.number})\n"
     )
 
-    m3u8_url, stream_headers = get_stream(
+    m3u8_url, stream_headers, subtitle_tracks = get_stream(
         scrape_serie.tmdb_id, 'tv',
         season=season_number, episode=int(obj_episode.number)
     )
@@ -72,9 +73,10 @@ def download_episode(obj_episode, index: int, scrape_serie: GetSerieInfo, season
     out_path = os.path.join(out_dir, f"{filename}.{extension_output}")
 
     return HLS_Downloader(
-        m3u8_url   = m3u8_url,
-        headers    = stream_headers or None,
-        output_path= out_path,
+        m3u8_url     = m3u8_url,
+        headers      = stream_headers or None,
+        output_path  = out_path,
+        other_tracks = subtitle_tracks or None,
     ).start()
 
 

--- a/VibraVid/services/cinezo/scrapper.py
+++ b/VibraVid/services/cinezo/scrapper.py
@@ -1,10 +1,11 @@
-# Cinezo series scrapper - uses TMDB for season/episode metadata
+# 17.04.26
 
 import logging
 from typing import List, Optional
 
 from VibraVid.services._base.object import SeasonManager, Season, Episode, EpisodeManager
 from VibraVid.utils.tmdb_client import tmdb_client
+
 
 logger = logging.getLogger(__name__)
 
@@ -26,11 +27,11 @@ class GetSerieInfo:
             return
         self._loaded = True
         try:
-            details = tmdb_client._make_request(f"tv/{self.tmdb_id}",
-                                                {"language": "it"}) or {}
+            details = tmdb_client._make_request(f"tv/{self.tmdb_id}", {"language": "it"}) or {}
             first_air = details.get('first_air_date', '') or ''
             if first_air:
                 self.series_year = int(first_air[:4])
+                
             for raw_s in details.get('seasons', []):
                 sn = raw_s.get('season_number', 0)
                 if sn == 0:

--- a/VibraVid/services/cinezo/scrapper.py
+++ b/VibraVid/services/cinezo/scrapper.py
@@ -1,0 +1,59 @@
+# Cinezo series scrapper - uses TMDB for season/episode metadata
+
+import logging
+from typing import List, Optional
+
+from VibraVid.services._base.object import SeasonManager, Season, Episode, EpisodeManager
+from VibraVid.utils.tmdb_client import tmdb_client
+
+logger = logging.getLogger(__name__)
+
+
+class GetSerieInfo:
+    """
+    Fetches season/episode metadata for a Cinezo series via TMDB.
+    """
+
+    def __init__(self, tmdb_id: int, series_name: str):
+        self.tmdb_id     = tmdb_id
+        self.series_name = series_name
+        self.seasons_manager = SeasonManager()
+        self._loaded = False
+
+    def _load(self):
+        if self._loaded:
+            return
+        self._loaded = True
+        try:
+            details = tmdb_client._make_request(f"tv/{self.tmdb_id}",
+                                                {"language": "it"}) or {}
+            for raw_s in details.get('seasons', []):
+                sn = raw_s.get('season_number', 0)
+                if sn == 0:
+                    continue  # skip specials
+
+                ep_count = raw_s.get('episode_count', 0)
+                em = EpisodeManager()
+                for ep_num in range(1, ep_count + 1):
+                    em.add(Episode(
+                        id     = ep_num,
+                        number = ep_num,
+                        name   = f"Episodio {ep_num}",
+                    ))
+
+                s = Season(id=sn, number=sn, name=raw_s.get('name', f"Stagione {sn}"), slug='')
+                s.episodes = em
+                self.seasons_manager.add(s)
+        except Exception as e:
+            logger.error(f"[Cinezo] TMDB series load failed: {e}")
+
+    def getNumberSeason(self) -> int:
+        self._load()
+        return len(self.seasons_manager.seasons)
+
+    def getEpisodeSeasons(self, season_number: int) -> list:
+        self._load()
+        season = self.seasons_manager.get_season_by_number(season_number)
+        if not season:
+            return []
+        return season.episodes.episodes

--- a/VibraVid/services/cinezo/scrapper.py
+++ b/VibraVid/services/cinezo/scrapper.py
@@ -17,6 +17,7 @@ class GetSerieInfo:
     def __init__(self, tmdb_id: int, series_name: str):
         self.tmdb_id     = tmdb_id
         self.series_name = series_name
+        self.series_year = None
         self.seasons_manager = SeasonManager()
         self._loaded = False
 
@@ -27,6 +28,9 @@ class GetSerieInfo:
         try:
             details = tmdb_client._make_request(f"tv/{self.tmdb_id}",
                                                 {"language": "it"}) or {}
+            first_air = details.get('first_air_date', '') or ''
+            if first_air:
+                self.series_year = int(first_air[:4])
             for raw_s in details.get('seasons', []):
                 sn = raw_s.get('season_number', 0)
                 if sn == 0:

--- a/VibraVid/services/guardaserie/__init__.py
+++ b/VibraVid/services/guardaserie/__init__.py
@@ -46,13 +46,25 @@ def title_search(query: str) -> int:
     # Create soup and find table
     soup = BeautifulSoup(response.text, "html.parser")
 
-    for serie_div in soup.find_all('div', class_='mlnew'):
+    for serie_div in soup.find_all('div', class_='movie'):
         try:
+            a   = serie_div.find('a')
+            img = serie_div.find('img')
+
+            title_tag = serie_div.find(class_=lambda c: c and 'title' in str(c).lower())
+            name = (title_tag.get_text(strip=True) if title_tag else
+                    a.get('title', '').replace('streaming guardaserie', '').strip() or
+                    a.get_text(strip=True))
+
+            image = (img.get('data-src') or img.get('src', '')) if img else ''
+            if image and image.startswith('/'):
+                image = site_constants.FULL_URL + image
+
             entries_manager.add(Entries(
-                name=serie_div.find('a').get("title").replace("streaming guardaserie", ""),
-                type='tv',
-                url=serie_div.find('a').get("href"),
-                image=f"{site_constants.FULL_URL}/{serie_div.find('img').get('src')}"
+                name  = name,
+                type  = 'tv',
+                url   = a.get('href', ''),
+                image = image,
             ))
 
         except Exception as e:

--- a/VibraVid/services/mostraguarda/__init__.py
+++ b/VibraVid/services/mostraguarda/__init__.py
@@ -52,7 +52,7 @@ def title_search(query: str) -> int:
             path_id=None,
             type='film',
             url='',  # Not needed for download
-            image=movie.get('poster_path'),
+            image=f"https://image.tmdb.org/t/p/w500{movie.get('poster_path')}" if movie.get('poster_path') else None,
             imdb_id=movie.get('imdb_id'),
             year=year
         )


### PR DESCRIPTION
## Summary

  - Adds full Cinezo.net integration as a new service (`VibraVid/services/cinezo/`)
  - Adds GUI API wrapper (`GUI/searchapp/api/cinezo.py`) with search and download support
  - Fixes Guardaserie scraper: updated CSS selector from `mlnew` → `movie`, robust title/image extraction
  - Fixes MostraGuarda: corrects TMDB poster URL (now prefixes full `https://image.tmdb.org/t/p/w500` path)

  ## Technical details — Cinezo decoder

  Cinezo uses a 4-layer obfuscation to protect stream URLs:

  1. **Base64** — outer wrapper
  2. **RC4** — symmetric stream cipher with a per-page key
  3. **Reverse** — string is reversed after RC4
  4. **AES-CBC** — final layer, key derived from page metadata

  The `client.py` handles key extraction, `scrapper.py` handles search/episode listing, `downloader.py` handles stream resolution and HLS download.

  ## Files changed

  | File | Type |
  |------|------|
  | `VibraVid/services/cinezo/__init__.py` | New |
  | `VibraVid/services/cinezo/client.py` | New |
  | `VibraVid/services/cinezo/scrapper.py` | New |
  | `VibraVid/services/cinezo/downloader.py` | New |
  | `GUI/searchapp/api/cinezo.py` | New |
  | `GUI/searchapp/api/__init__.py` | Modified |
  | `VibraVid/services/guardaserie/__init__.py` | Fixed |
  | `VibraVid/services/mostraguarda/__init__.py` | Fixed |
