### PR TITLE
Fix hybrid track manager

### DIFF
--- a/Test/Downloads/HLS_HYBRID.py
+++ b/Test/Downloads/HLS_HYBRID.py
@@ -1,0 +1,52 @@
+# 23.06.24
+# ruff: noqa: E402
+
+import os
+import sys
+
+src_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+sys.path.append(src_path)
+
+
+from VibraVid.utils import config_manager
+from VibraVid.core.downloader import HLS_Downloader
+
+conf_extension = config_manager.config.get("PROCESS", "extension")
+
+other_tracks = [
+    {
+        "type": "video:DV",
+        "url": "",
+        "language": "und",
+        "name": "2160p DV",
+    },
+    {
+        "type": "audio",
+        "url": "",
+        "language": "en",
+        "name": "English E-AC3",
+        "extension": "m4a",
+        "default": True,
+    },
+    {
+        "type": "subtitle",
+        "url": "",
+        "language": "en",
+        "name": "English-Forced",
+        "extension": "vtt",
+        "forced": True,
+    },
+]
+
+main_hdr10_track = "https://vod-ak-amt.tv.apple.com/itunes-assets/HLSVideo211/v4/e6/31/07/e6310703-34ef-c097-4f48-b2b3ed41b196/P1346664989_A1890577745_FF_video_gr798_HDR10Plus_3828x1592_-.m3u8"
+
+hls_process = HLS_Downloader(
+    m3u8_url=main_hdr10_track,
+    headers={},
+    output_path=fr".\Video\Prova_Hybrid.{conf_extension}",
+    key="kid:key|kid:key",
+    other_tracks=other_tracks
+)
+
+out_path, need_stop = hls_process.start()
+print(f"Downloaded to: {out_path}, Stopped: {need_stop}")

--- a/Test/Downloads/HLS_HYBRID.py
+++ b/Test/Downloads/HLS_HYBRID.py
@@ -38,7 +38,7 @@ other_tracks = [
     },
 ]
 
-main_hdr10_track = "https://vod-ak-amt.tv.apple.com/itunes-assets/HLSVideo211/v4/e6/31/07/e6310703-34ef-c097-4f48-b2b3ed41b196/P1346664989_A1890577745_FF_video_gr798_HDR10Plus_3828x1592_-.m3u8"
+main_hdr10_track = ""
 
 hls_process = HLS_Downloader(
     m3u8_url=main_hdr10_track,

--- a/VibraVid/core/downloader/base.py
+++ b/VibraVid/core/downloader/base.py
@@ -1,7 +1,8 @@
-﻿# 2.03.26
+# 2.03.26
 
 import os
 import json
+import re
 import shutil
 import logging
 from pathlib import Path
@@ -28,25 +29,54 @@ DEBUG_TRACK_JSON = config_manager.config.get_bool("DEFAULT", "debug_track_json")
 
 
 class BaseDownloader:
-    """
-    Shared base for HLS_Downloader and DASH_Downloader.
+    def _extract_season_episode(self, output_path: str) -> tuple:
+        """Extract season and episode numbers from output_path using regex patterns."""
+        season = 0
+        episode = 0
+        
+        # Try to match S##E## or S#E# pattern
+        match = re.search(r'[/\\]S(\d+)[/\\].*?S\d+E(\d+)', output_path)
+        if match:
+            season = int(match.group(1))
+            episode = int(match.group(2))
+            return season, episode
+        
+        # Fallback: try to match just S##E## in filename
+        match = re.search(r'S(\d+)E(\d+)', output_path)
+        if match:
+            season = int(match.group(1))
+            episode = int(match.group(2))
+        
+        return season, episode
 
-    Subclasses are responsible for setting up:
-        self.output_path = full final file path
-        self.filename_base = stem without extension
-        self.output_dir = temp working directory
-        self.download_id = tracker ID (or None)
-        self.last_merge_result = populated by merge methods
-        self.copied_subtitles = list staging subtitles for deferred copy
-        self.copied_audios = list staging audios for deferred copy
-        self.audio_only = True when there is no video track
-    """
     def _build_tracks_json(self, streams: list, keys: list, manifest_url: str) -> dict:
-        """Build a JSON-serializable dict of selected tracks only. """
+        """Build a JSON-serializable dict of selected tracks only."""
         videos = []
         audios: Dict[str, list] = {}
         subtitles: Dict[str, str] = {}
-        other_tracks = list(getattr(self, "other_tracks", []) or [])
+        other_tracks = []
+        for track in list(getattr(self, "other_tracks", []) or []):
+            if not isinstance(track, dict):
+                continue
+            normalized_track = {
+                "type": track.get("type"),
+                "url": track.get("url"),
+                "language": track.get("language"),
+            }
+            if normalized_track["type"] and normalized_track["url"]:
+                other_tracks.append(normalized_track)
+
+        def _to_mbps(value):
+            if value is None:
+                return None
+            try:
+                bps = float(value)
+            except (TypeError, ValueError):
+                return None
+            if bps <= 0:
+                return None
+            mbps = bps / 1_000_000
+            return f"{mbps:.3f}".rstrip("0").rstrip(".") + " Mbps"
 
         for s in streams:
             if not getattr(s, "selected", False):
@@ -54,20 +84,31 @@ class BaseDownloader:
             stype = getattr(s, "type", "") or ""
 
             if stype == "video":
+                codec = s.get_short_codec() if hasattr(s, 'get_short_codec') else getattr(s, "codecs", None)
+                if not codec:
+                    codec = "H.264"
                 videos.append({
                     "manifest_url": manifest_url,
                     "quality": getattr(s, "resolution", None),
-                    "bitrate": getattr(s, "bitrate", None),
+                    "bitrate": _to_mbps(getattr(s, "bitrate", None)),
+                    "codec": codec,
                 })
 
             elif stype == "audio":
+                audio_url = getattr(s, "playlist_url", None) or getattr(s, "url", None) or manifest_url
+                if audio_url == manifest_url:
+                    continue  # same manifest as video, skip
                 lang = (getattr(s, "language", None) or "und").strip()
+                codec = s.get_short_codec() if hasattr(s, 'get_short_codec') else getattr(s, "codecs", None)
+                if not codec:
+                    codec = "AAC"
+                audio_bitrate = _to_mbps(getattr(s, "bitrate", None))
+                if audio_bitrate is None:
+                    audio_bitrate = "128kbps"
                 entry = {
-                    "manifest_url": manifest_url,
-                    "codec": getattr(s, "codecs", None),
-                    "channels": getattr(s, "channels", None),
-                    "bitrate": getattr(s, "bitrate", None),
-                    "url": getattr(s, "playlist_url", None) or getattr(s, "url", None),
+                    "manifest_url": audio_url,
+                    "codec": codec,
+                    "bitrate": audio_bitrate,
                 }
                 audios.setdefault(lang, []).append(entry)
 
@@ -76,26 +117,57 @@ class BaseDownloader:
                 name = getattr(s, "name", None) or lang
                 label = f"{lang} - {name}" if name and name != lang else lang
                 url = getattr(s, "playlist_url", None) or getattr(s, "url", None)
+                
+                if not url and manifest_url:
+                    url = manifest_url
+
+                if url == manifest_url:
+                    continue
+                
                 subtitles[label] = url
 
-        return {
-            "videos": videos,
-            "audios": audios,
-            "subtitles": subtitles,
-            "other_tracks": other_tracks,
-            "keys": list(keys) if keys else [],
-        }
+        formatted_keys = []
+        for k in (keys or []):
+            if isinstance(k, (list, tuple)) and len(k) == 2:
+                formatted_keys.append(f"{k[0]}:{k[1]}")
+            else:
+                formatted_keys.append(str(k))
+
+        result = {"videos": videos}
+        if audios:
+            result["audios"] = audios
+        result["subtitles"] = subtitles
+        result["other_tracks"] = other_tracks
+        result["keys"] = formatted_keys
+        return result
 
     def _log_tracks_json(self, streams: list, keys: list, manifest_url: str) -> None:
         """Emit a TRACKS_JSON logger.info"""
         from VibraVid.core.ui.tracker import context_tracker
         tracks = self._build_tracks_json(streams, keys, manifest_url)
+        
+        # Extract season/episode from output_path if available
+        season, episode = 0, 0
+        output_path = getattr(self, "output_path", "")
+        if output_path:
+            season, episode = self._extract_season_episode(output_path)
+        
+        # Fallback to context_tracker if extraction failed
+        if season == 0:
+            season = context_tracker.season or 0
+        if episode == 0:
+            episode = context_tracker.episode or 0
+        
+        # Determine media type: if season or episode > 0, it's a TV series, otherwise it's a film
+        media_type = context_tracker.media_type or "Film"
+        if season > 0 or episode > 0:
+            media_type = "TV"
+        
         payload = {
             "name": context_tracker.title or self.filename_base,
-            "type": (context_tracker.media_type or "UNKNOWN").upper(),
-            "season": context_tracker.season  or 0,
-            "episode": context_tracker.episode or 0,
-            "episode_name": context_tracker.episode_name,
+            "type": media_type.upper(),
+            "season": season,
+            "episode": episode,
             "tracks": tracks,
         }
         if DEBUG_TRACK_JSON:
@@ -188,11 +260,12 @@ class BaseDownloader:
 
         for track in other_track_results:
             track_kind = (track.get("kind") or track.get("type") or "").lower()
-            if track_kind == "video":
+            base_kind = track_kind.split(":")[0]   # "video:hdr10" → "video"
+            if base_kind == "video":
                 continue
-            if track_kind == "audio":
+            if base_kind == "audio":
                 audio_tracks.append(track)
-            elif track_kind == "subtitle":
+            elif base_kind == "subtitle":
                 subtitle_tracks.append(track)
 
         if video_track is None:
@@ -221,7 +294,7 @@ class BaseDownloader:
         if other_track_results or (video_probe or {}).get("dolby_vision"):
             hybrid_file = build_hybrid_output(
                 video_track=video_track if isinstance(video_track, dict) else {"path": video_path},
-                other_videos=[track for track in other_track_results if (track.get("kind") or "").lower() == "video"],
+                other_videos=[track for track in other_track_results if (track.get("kind") or track.get("type") or "").lower().split(":")[0] == "video"],
                 audio_tracks=audio_tracks,
                 subtitle_tracks=subtitle_tracks,
                 output_path=self.output_path,
@@ -229,7 +302,10 @@ class BaseDownloader:
             )
             if hybrid_file:
                 self.last_merge_result = {"hybrid": True, "output": hybrid_file}
+                # hybrid_file include già audio e subtitle via mkvmerge:
+                # non chiamare join_audios/join_subtitles separatamente
                 return hybrid_file
+
 
         if not audio_tracks and not subtitle_tracks:
             console.print("[cyan]\nNo additional tracks to merge, muxing video...")

--- a/VibraVid/core/downloader/base.py
+++ b/VibraVid/core/downloader/base.py
@@ -29,6 +29,21 @@ DEBUG_TRACK_JSON = config_manager.config.get_bool("DEFAULT", "debug_track_json")
 
 
 class BaseDownloader:
+
+    @staticmethod
+    def _resolve_url(url_or_path: str) -> str:
+        if not url_or_path:
+            return url_or_path
+        stripped = url_or_path.strip()
+
+        if re.match(r'^[a-zA-Z][a-zA-Z0-9+\-.]*://', stripped):
+            return stripped
+
+        path = Path(stripped)
+        if path.exists() and path.is_file():
+            return path.resolve().as_uri()
+        return stripped
+
     def _extract_season_episode(self, output_path: str) -> tuple:
         """Extract season and episode numbers from output_path using regex patterns."""
         season = 0

--- a/VibraVid/core/downloader/dash.py
+++ b/VibraVid/core/downloader/dash.py
@@ -191,7 +191,7 @@ class DASH_Downloader(BaseDownloader):
             - cookies: HTTP cookies for authenticated requests.
             - max_segments: Maximum number of segments to download (for testing). Default: None (all).
         """
-        self.mpd_url = str(mpd_url).strip() if mpd_url else None
+        self.mpd_url = self._resolve_url(str(mpd_url).strip()) if mpd_url else None
         self.mpd_headers = mpd_headers or get_headers()
         self.other_tracks = [dict(track or {}) for track in (other_tracks or [])]
 

--- a/VibraVid/core/downloader/hls.py
+++ b/VibraVid/core/downloader/hls.py
@@ -182,35 +182,34 @@ class HLS_Downloader(BaseDownloader):
         return result
 
     def _fetch_keys(self, drm_psshs: Dict[str, List[Dict]]) -> List[str]:
-        """
-        Dispatch key fetch to DRMManager.
-
-        All DRM type comparisons use plain string literals ('widevine',
-        'playready', 'auto') — never DRMSystem / DRMInfo class attributes.
-        """
-        drm_manager = DRMManager(
-            get_wvd_path(),
-            get_prd_path(),
-            config_manager.config.get_dict("DRM", "widevine", default={}),
-            config_manager.config.get_dict("DRM", "playready", default={}),
-            config_manager.config.get_bool("DRM", "prefer_remote_cdm"),
-        )
-        pref = self.drm_preference  # 'widevine' | 'playready' | 'auto'
+        """Fetch decryption keys based on collected PSSH data and DRM preference."""
+        drm_manager = DRMManager(...)
+        pref = self.drm_preference
         keys = None
 
         if pref in (_WV, "auto") and drm_psshs.get("WV"):
             try:
-                keys = drm_manager.get_wv_keys(drm_psshs["WV"], self.license_url, self.license_certificate, self.license_headers, self.key)
+                keys = drm_manager.get_wv_keys(
+                    drm_psshs["WV"],
+                    self.license_url,
+                    license_certificate=self.license_certificate,
+                    headers=self.license_headers,
+                    key=self.key,
+                )
             except Exception as exc:
                 logger.error(f"Widevine key fetch failed: {exc}")
 
         if not keys and pref in (_PR, "auto") and drm_psshs.get("PR"):
             try:
-                keys = drm_manager.get_pr_keys(drm_psshs["PR"], self.license_url, self.license_headers, self.key)
+                keys = drm_manager.get_pr_keys(
+                    drm_psshs["PR"],
+                    self.license_url,
+                    headers=self.license_headers,
+                    key=self.key,
+                )
             except Exception as exc:
                 logger.error(f"PlayReady key fetch failed: {exc}")
 
-        # Manual key passed directly
         if not keys and self.key:
             keys = [self.key] if isinstance(self.key, str) else list(self.key)
 

--- a/VibraVid/core/downloader/hls.py
+++ b/VibraVid/core/downloader/hls.py
@@ -9,7 +9,6 @@ from rich.console import Console
 
 from VibraVid.utils import config_manager, os_manager
 from VibraVid.utils.http_client import get_headers
-from VibraVid.setup import get_wvd_path, get_prd_path
 from VibraVid.core.ui.tracker import download_tracker, context_tracker
 from VibraVid.core.utils.media_players import MediaPlayers
 

--- a/VibraVid/core/downloader/hls.py
+++ b/VibraVid/core/downloader/hls.py
@@ -62,7 +62,7 @@ class HLS_Downloader(BaseDownloader):
             - cookies: HTTP cookies for authenticated requests.
             - max_segments: Maximum number of segments to download (for testing). Default: None (all).
         """
-        self.m3u8_url = str(m3u8_url).strip()
+        self.m3u8_url = self._resolve_url(str(m3u8_url).strip())
         self.headers = headers or get_headers()
         self.license_url = str(license_url).strip() if license_url else None
         self.license_headers = license_headers or self.headers

--- a/VibraVid/core/downloader/ism.py
+++ b/VibraVid/core/downloader/ism.py
@@ -38,7 +38,7 @@ class ISM_Downloader(BaseDownloader):
         max_segments: Optional[int] = None,
         other_tracks: Optional[list] = None,
     ):
-        self.ism_url = str(ism_url).strip()
+        self.ism_url = self._resolve_url(str(ism_url).strip())
         self.headers = headers or get_headers()
         self.license_url = str(license_url).strip() if license_url else None
         self.license_headers = license_headers or self.headers

--- a/VibraVid/core/manifest/ism.py
+++ b/VibraVid/core/manifest/ism.py
@@ -84,6 +84,19 @@ class ISMParser:
                 logger.error(f"ISMParser: injected XML parse error: {exc}")
                 self._injected = None   # fall through to network fetch
 
+        if self.ism_url.startswith("file://"):
+            try:
+                from urllib.request import url2pathname
+                local_path = Path(url2pathname(urlparse(self.ism_url).path))
+                self.raw_content = local_path.read_text(encoding="utf-8")
+                self._base_url = local_path.parent.as_uri() + "/"
+                self._root = ET.fromstring(self.raw_content)
+                return True
+            except Exception as exc:
+                console.print(f"[red]Failed to read local ISM manifest: {exc}.")
+                logger.error(f"ISMParser: local file read failed: {exc}")
+                return False
+
         try:
             timeout = config_manager.config.get_int("REQUESTS", "timeout")
             hdrs = dict(self.headers)

--- a/VibraVid/core/manifest/m3u8.py
+++ b/VibraVid/core/manifest/m3u8.py
@@ -411,11 +411,39 @@ class HLSParser:
                                 info.kid = kid
                     except (json.JSONDecodeError, TypeError, AttributeError, UnicodeDecodeError, ValueError):
                         is_wv = "edef8ba9" in attrs.lower() or "edef8ba9" in full_uri.lower() or "widevine" in attrs.lower()
-                        is_pr = "9a04f079" in attrs.lower() or "9a04f079" in full_uri.lower() or "playready" in attrs.lower() or "com.microsoft" in attrs.lower()
-                        
+                        is_pr = ("9a04f079" in attrs.lower() or "9a04f079" in full_uri.lower() or "playready" in attrs.lower() or "com.microsoft" in attrs.lower())
+                        if not is_pr and not is_wv:
+                            try:
+                                xml_text = decoded.decode("utf-16-le", errors="ignore")
+                                if "<WRMHEADER" in xml_text or "<KID" in xml_text:
+                                    is_pr = True
+                            except Exception:
+                                pass
+
                         if is_wv:
                             info.set_pssh(b64, "WV")
                         elif is_pr:
+                            try:
+                                xml_text = decoded.decode("utf-16-le", errors="ignore")
+                                if "<WRMHEADER" in xml_text or "<KID" in xml_text:
+                                    import re as _re
+                                    kid_m = _re.search(r'VALUE="([A-Za-z0-9+/=]+)"', xml_text)
+                                    if kid_m:
+                                        kid_b64 = kid_m.group(1)
+                                        kid_bytes = base64.b64decode(kid_b64 + "==")
+                                        if len(kid_bytes) >= 16:
+                                            kid_hex = (
+                                                kid_bytes[3::-1].hex()
+                                                + kid_bytes[5:3:-1].hex()
+                                                + kid_bytes[7:5:-1].hex()
+                                                + kid_bytes[8:10].hex()
+                                                + kid_bytes[10:16].hex()
+                                            )
+                                            info.set_kid(kid_hex)
+                                            logger.info(f"PlayReady WRM Header KID extracted: {kid_hex}")
+                            except Exception as exc:
+                                logger.warning(f"PlayReady WRM KID extraction failed: {exc}")
+                            
                             info.set_pssh(b64, "PR")
                         else:
                             info.set_pssh(b64)

--- a/VibraVid/core/manifest/m3u8.py
+++ b/VibraVid/core/manifest/m3u8.py
@@ -83,6 +83,19 @@ class HLSParser:
         if self._injected:
             self.raw_content = self._injected
             return True
+        
+        if self.m3u8_url.startswith("file://"):
+            try:
+                from urllib.request import url2pathname
+                local_path = Path(url2pathname(urlparse(self.m3u8_url).path))
+                self.raw_content = local_path.read_text(encoding="utf-8")
+                self._base_url = local_path.parent.as_uri() + "/"
+                return True
+            except Exception as exc:
+                console.print(f"[red]Failed to read local HLS manifest: {exc}.")
+                logger.error(f"HLSParser: local file read failed: {exc}")
+                return False
+
         try:
             hdrs = dict(self.headers)
             hdrs.setdefault("User-Agent", get_headers().get("User-Agent", ""))

--- a/VibraVid/core/manifest/mpd.py
+++ b/VibraVid/core/manifest/mpd.py
@@ -196,6 +196,20 @@ class DashParser:
                 logger.error(f"DashParser: injected XML parse error: {exc}")
                 self._injected = None
 
+        if self.mpd_url.startswith("file://"):
+            try:
+                from urllib.request import url2pathname
+                local_path = Path(url2pathname(urlparse(self.mpd_url).path))
+                self.raw_content = local_path.read_text(encoding="utf-8")
+                self._base_url = local_path.parent.as_uri() + "/"
+                self._root = ET.fromstring(self.raw_content)
+                self._resolve_base_url()
+                return True
+            except Exception as exc:
+                console.print(f"[red]Failed to read local DASH manifest: {exc}.")
+                logger.error(f"DashParser: local file read failed: {exc}")
+                return False
+
         try:
             timeout = config_manager.config.get_int("REQUESTS", "timeout")
             hdrs = dict(self.headers)

--- a/VibraVid/core/manifest/stream.py
+++ b/VibraVid/core/manifest/stream.py
@@ -207,9 +207,16 @@ class Segment:
     size: int = 0
     downloaded: bool = False
     byte_range: str = ""  # e.g. "12132-31195" for byte-range requests
+    duration: float = 0.0          # seconds; set by parser when known (e.g. #EXTINF or <S d=…/>)
+    estimated_size: int = 0        # bytes; computed from stream bitrate × duration when size == 0
+
+    def get_effective_size(self) -> int:
+        """Return real size if downloaded/known, otherwise the estimate."""
+        return self.size if self.size else self.estimated_size
 
     def __repr__(self) -> str:
-        return f"Segment({self.number}, {self.seg_type})"
+        dur_s = f", {self.duration:.3f}s" if self.duration else ""
+        return f"Segment({self.number}, {self.seg_type}{dur_s})"
 
 
 @dataclass
@@ -271,8 +278,61 @@ class Stream:
     is_live: bool = False
     is_wvtt_mp4: bool = False
 
+    # ── Size estimation ───────────────────────────────────────────────────────
+    # Populated by compute_estimated_size(); do not set manually.
+    estimated_size: int = 0        # bytes; total stream size estimate
+
     def add_segment(self, seg: Segment) -> None:
         self.segments.append(seg)
+
+    def compute_estimated_size(self, bitrate_override: int = 0) -> int:
+        """
+        Compute and store an estimated total size in bytes, then return it.
+
+        Priority order:
+        1. Sum of real ``Segment.size`` values (when already downloaded/known).
+        2. Sum of ``Segment.estimated_size`` values (pre-filled by parser from
+           per-segment durations × bitrate, e.g. from DASH <S d=…/> or
+           HLS #EXTINF).
+        3. Fallback: ``(avg_bitrate or bitrate or bitrate_override) × duration``
+           using the stream-level duration.
+
+        The result is stored in ``self.estimated_size`` and also returned.
+        """
+        # 1. Real sizes from already-downloaded segments
+        real_total = sum(s.size for s in self.segments if s.size)
+        if real_total:
+            self.estimated_size = real_total
+            return self.estimated_size
+
+        # 2. Per-segment estimates (set by parser from per-segment duration × bitrate)
+        seg_est_total = sum(s.estimated_size for s in self.segments if s.estimated_size)
+        if seg_est_total:
+            self.estimated_size = seg_est_total
+            return self.estimated_size
+
+        # 3. Stream-level fallback: bitrate × total duration
+        bw = bitrate_override or self.avg_bitrate or self.bitrate
+        if bw and self.duration > 0:
+            self.estimated_size = int(bw / 8 * self.duration)
+            return self.estimated_size
+
+        self.estimated_size = 0
+        return 0
+
+    @property
+    def estimated_size_display(self) -> str:
+        """Human-readable estimated size, e.g. '1.2 GB', '450 MB', '820 KB'."""
+        b = self.estimated_size
+        if not b:
+            return "N/A"
+        if b >= 1_073_741_824:
+            return f"~{b / 1_073_741_824:.2f} GB"
+        if b >= 1_048_576:
+            return f"~{b / 1_048_576:.1f} MB"
+        if b >= 1_024:
+            return f"~{b / 1_024:.0f} KB"
+        return f"~{b} B"
 
     # ─── Display helpers ───────────────────────────────────────────────────────
     @property

--- a/VibraVid/core/muxing/hybrid.py
+++ b/VibraVid/core/muxing/hybrid.py
@@ -107,29 +107,38 @@ def _to_annexb(input_path: Path, output_path: Path) -> bool:
     return _run_command(cmd, f"ffmpeg annexb {input_path.name}")
 
 
-def _select_hybrid_video(video_track: Dict[str, Any], other_videos: Iterable[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+def _select_hybrid_video(video_track, other_videos):
     base_path = str(video_track.get("path") or "").strip()
     if not base_path:
         return None
 
     base_probe = video_track.get("probe") or probe_media_file(base_path)
-    if base_probe.get("dolby_vision") and not list(other_videos):
+    other_list = list(other_videos)
+
+    # Case 1: base is DV and no other candidates, use it as is (e.g. DV-only source)
+    if base_probe.get("dolby_vision") and not other_list:
         return video_track
 
-    if not base_probe.get("hdr"):
-        return None
+    # Case 2: base is HDR10 and no other candidates, use it as is (e.g. HDR10-only source)
+    if base_probe.get("hdr") and not base_probe.get("dolby_vision"):
+        for candidate in other_list:
+            probe = candidate.get("probe") or probe_media_file(str(candidate.get("path", "")))
+            candidate["probe"] = probe
+            if probe.get("dolby_vision") or (candidate.get("tag") or "").lower() == "dv":
+                return candidate
 
-    dv_candidate = None
-    for candidate in other_videos:
-        if not candidate:
-            continue
-        probe = candidate.get("probe") or probe_media_file(str(candidate.get("path", "")))
-        candidate["probe"] = probe
-        if probe.get("dolby_vision") or (candidate.get("tag") or "").lower() == "dv":
-            dv_candidate = candidate
-            break
+    # Case 3: base is DV but has HDR10 candidates, prefer a non-DV HDR10 candidate if available (e.g. mixed source)
+    if base_probe.get("dolby_vision"):
+        for candidate in other_list:
+            probe = candidate.get("probe") or probe_media_file(str(candidate.get("path", "")))
+            candidate["probe"] = probe
+            tag = (candidate.get("tag") or candidate.get("type") or "").lower()
+            if probe.get("hdr") and not probe.get("dolby_vision"):
+                return candidate
+            if "hdr" in tag:
+                return candidate
 
-    return dv_candidate
+    return None
 
 
 def build_hybrid_output(

--- a/VibraVid/core/source/base.py
+++ b/VibraVid/core/source/base.py
@@ -39,6 +39,7 @@ def resolve_subtitle_url_sync(url: str, headers: Dict) -> Tuple[str, str]:
     URL is extracted and its extension is used.  Returns ``(final_url, ext)``
     where *ext* may be an empty string if nothing recognisable was found.
     """
+    from urllib.parse import urljoin
     try:
         hdrs = dict(headers)
         hdrs.setdefault("User-Agent", get_headers().get("User-Agent", ""))
@@ -56,9 +57,10 @@ def resolve_subtitle_url_sync(url: str, headers: Dict) -> Tuple[str, str]:
         for line in text.splitlines():
             line = line.strip()
             if line and not line.startswith("#"):
-                resolved_ext = ext_from_url(line, "")
+                absolute_url = urljoin(url, line)
+                resolved_ext = ext_from_url(absolute_url, "")
                 logger.info(f"Resolved HLS subtitle manifest -> segment {line!r} (ext={resolved_ext!r})")
-                return line, resolved_ext
+                return absolute_url, resolved_ext
         
         logger.info(f"resolve_subtitle_url_sync: manifest at {url!r} had no segments")
         return url, ""

--- a/VibraVid/core/source/subtitle.py
+++ b/VibraVid/core/source/subtitle.py
@@ -123,15 +123,16 @@ def normalize_sub_filename(lang_raw: str, track_info: Dict = None) -> Tuple[str,
 def ext_from_url(url: str, fallback: str = "UNK") -> str:
     """Detect subtitle/audio format from URL path, ignoring query string."""
     path = url.split("?")[0].lower()
-    for ext in ("vtt", "srt", "ass", "ssa", "ttml2", "ttml", "xml", "dfxp", "m4a", "aac", "mp3"):
+    for ext in ("webvtt", "vtt", "srt", "ass", "ssa", "ttml2", "ttml", "xml", "dfxp", "m4a", "aac", "mp3"):
         if path.endswith(f".{ext}"):
-            return ext
+            return "vtt" if ext == "webvtt" else ext
     
     return fallback
 
 
 async def resolve_url(client: Any, url: str, track_type: str) -> Tuple[str, str]:
     """If *url* points to an HLS manifest (#EXTM3U), resolve and return the first media segment URL and its detected format."""
+    from urllib.parse import urljoin
     try:
         resp = await client.get(url)
         resp.raise_for_status()
@@ -144,9 +145,10 @@ async def resolve_url(client: Any, url: str, track_type: str) -> Tuple[str, str]
         for line in text.splitlines():
             line = line.strip()
             if line and not line.startswith("#"):
-                fmt = ext_from_url(line, "UNK")
+                absolute_url = urljoin(url, line)
+                fmt = ext_from_url(absolute_url, "UNK")
                 logger.info(f"Resolved manifest → segment: {line} (fmt={fmt})")
-                return line, fmt
+                return absolute_url, fmt
 
         logger.error(f"Manifest parsed but no segment found in {url!r}")
         return url, ext_from_url(url, "UNK")


### PR DESCRIPTION
1. Risolto problema dove l'estrazione di kid widevine \ playready \ fairplay non avveniva per tracce m3u8 
2. Risolto problema subtitle per other_track non venivano scaricati correttamente se webvtt
3. Risolto problema con debug_track_json = True dove veniva indicato che un episodio aveva type FILM invece di TV
4. Aggiunta stima dimensione finale per stream video o audio da usare cosi:

for seg in stream.segments:
    seg.estimated_size = int((stream.avg_bitrate or stream.bitrate) / 8 * seg.duration)

stream.compute_estimated_size()
print(stream.estimated_size_display)