### PR TITLE
fix(streamingcommunity): deduplicate search results across language v…

### DIFF
--- a/GUI/searchapp/api/streamingcommunity.py
+++ b/GUI/searchapp/api/streamingcommunity.py
@@ -65,7 +65,18 @@ class StreamingCommunityAPI(BaseStreamingAPI):
                 )
                 results.append(media_item)
         
-        return results
+        # Dedup by ID: search runs for both 'it' and 'en', same title appears twice.
+        # Keep 'it' version when both exist for the same ID.
+        seen: dict = {}
+        deduped = []
+        for item in results:
+            key = item.id
+            if key not in seen:
+                seen[key] = len(deduped)
+                deduped.append(item)
+            elif item.provider_language == 'it' and deduped[seen[key]].provider_language != 'it':
+                deduped[seen[key]] = item
+        return deduped
 
     def get_series_metadata(self, media_item: Entries) -> Optional[List[Season]]:
         """


### PR DESCRIPTION
## Summary

  - SC search queries both `/it` and `/en` endpoints in parallel; titles present in both return twice in the results
  grid
  - Deduplicate by `id` in `StreamingCommunityAPI.search()`, keeping the Italian version when both exist

  ## Root cause

  `search_fn` fires two parallel requests — one to `/{lang}/search?q=…` for each configured language. Any title indexed
  in both `/it` and `/en` produces two `Entries` objects with the same `id` but different `provider_language`. The GUI
  layer received both and rendered both cards.

  ## Test plan
  - [ ] Search for a common title (e.g. "Inception", "MASH") — each result appears once
  - [ ] Single-language titles still appear correctly
  - [ ] `provider_language` on each card matches the correct source language