### PR TITLE
[Fix] Docker Create .cache/arr/ before Django logging init

### DIFF
--- a/GUI/webgui/settings.py
+++ b/GUI/webgui/settings.py
@@ -128,6 +128,12 @@ ARR_WEBHOOK_PRIORITY_ENABLED = _env_flag("ARR_WEBHOOK_PRIORITY_ENABLED", True)
 ARR_NATIVE_WEBHOOK_PRIORITY_WINDOW_SECONDS = _env_int("ARR_NATIVE_WEBHOOK_PRIORITY_WINDOW_SECONDS", 120)
 ARR_SEERR_FALLBACK_DELAY_SECONDS = _env_int("ARR_SEERR_FALLBACK_DELAY_SECONDS", 20)
 
+_ARR_LOG_DIR = PROJECT_ROOT / ".cache" / "arr"
+try:
+    _ARR_LOG_DIR.mkdir(parents=True, exist_ok=True)
+except Exception:
+    pass
+
 # ── Logging Configuration ────────────────────────────────────────────────────────
 LOGGING = {
     "version": 1,


### PR DESCRIPTION
The arr_file FileHandler in webgui/settings.py points to PROJECT_ROOT/.cache/arr/arr_<timestamp>.log, but nothing created the directory. First startup failed with FileNotFoundError and Django reported "Unable to configure handler 'arr_file'", so the GUI server never started.

Mirror the _DB_DIR.mkdir(parents=True, exist_ok=True) pattern already used a few lines above to ensure the log directory exists before LOGGING is evaluated.