### PR TITLE
feat(docker): env-var-driven compose + .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,48 @@
+# VibraVid — environment variable overrides for docker-compose.yml
+# Copy this file to .env and edit to match your setup:
+#   cp .env.example .env
+# Lines starting with # are comments and have no effect.
+# Variables left commented use the defaults built into docker-compose.yml.
+
+# ── Container / Network ─────────────────────────────────────────────────────
+
+# Host port mapped to the container's 8000.
+# Change if another service already uses 8000.
+# VIBRAVID_PORT=8000
+
+# Docker container name. Useful when running multiple instances (e.g. prod + demo).
+# VIBRAVID_CONTAINER_NAME=vibravid
+
+# ── Storage paths ────────────────────────────────────────────────────────────
+# Each variable accepts either:
+#   - a named Docker volume (default, created automatically), or
+#   - an absolute host path for a bind mount (NAS / home server use case).
+#
+# NAS example (Synology):
+#   VIBRAVID_VIDEO_DIR=/volume2/Movies
+#   VIBRAVID_DB_DIR=/volume1/docker/vibravid/db
+#   VIBRAVID_CONFIG_DIR=/volume1/docker/vibravid/conf
+#   VIBRAVID_LOGS_DIR=/volume1/docker/vibravid/logs
+
+# Where downloaded content is stored on the host.
+# VIBRAVID_VIDEO_DIR=vibravid_videos
+
+# SQLite database directory on the host.
+# VIBRAVID_DB_DIR=vibravid_db
+
+# App configuration directory (config.json, login.json, domains.json).
+# VIBRAVID_CONFIG_DIR=vibravid_config
+
+# Application logs directory.
+# VIBRAVID_LOGS_DIR=vibravid_logs
+
+# ── Django / Security ────────────────────────────────────────────────────────
+
+# Comma-separated list of hostnames / IPs Django will accept requests for.
+# Add your NAS IP or domain if accessing from another machine on the LAN.
+# Example: ALLOWED_HOSTS=localhost,127.0.0.1,192.168.1.100,nas.local
+# ALLOWED_HOSTS=localhost,127.0.0.1
+
+# CSRF trusted origins — must include the scheme (http:// or https://).
+# Example: CSRF_TRUSTED_ORIGINS=http://192.168.1.100:8000,https://nas.local
+# CSRF_TRUSTED_ORIGINS=http://localhost:8000,http://127.0.0.1:8000

--- a/.github/docs/it/README.md
+++ b/.github/docs/it/README.md
@@ -640,6 +640,45 @@ docker-compose logs -f      # Visualizza log
 docker-compose down         # Ferma (i dati vengono preservati)
 ```
 
+Per utenti NAS (Synology, TrueNAS, Unraid, ecc.) vedere **[docs/NAS.md](../../docs/NAS.md)** per una guida passo passo che include bind mount e configurazione dei permessi.
+
+### Percorsi e porte personalizzate
+
+Copiare il template e modificare i valori necessari:
+
+```bash
+cp .env.example .env
+```
+
+Variabili principali (elenco completo in `.env.example`):
+
+| Variabile | Default | Descrizione |
+|---|---|---|
+| `VIBRAVID_PORT` | `8000` | Porta host esposta dal container |
+| `VIBRAVID_VIDEO_DIR` | named volume | Dove finiscono i download sull'host (es. `/volume2/Film`) |
+| `VIBRAVID_DB_DIR` | named volume | Percorso host del database SQLite |
+| `VIBRAVID_CONFIG_DIR` | named volume | Percorso host per `config.json` / `login.json` |
+| `VIBRAVID_LOGS_DIR` | named volume | Percorso host per i log dell'applicazione |
+| `ALLOWED_HOSTS` | `localhost,127.0.0.1` | Hostname accettati da Django |
+| `CSRF_TRUSTED_ORIGINS` | `http://localhost:8000,...` | Origini per la validazione CSRF |
+
+**Esempio NAS** — download su share NAS, porta 9000:
+
+```env
+VIBRAVID_PORT=9000
+VIBRAVID_VIDEO_DIR=/volume2/Film
+VIBRAVID_DB_DIR=/volume1/docker/vibravid/db
+VIBRAVID_CONFIG_DIR=/volume1/docker/vibravid/conf
+VIBRAVID_LOGS_DIR=/volume1/docker/vibravid/logs
+ALLOWED_HOSTS=localhost,127.0.0.1,192.168.1.100
+CSRF_TRUSTED_ORIGINS=http://192.168.1.100:9000
+```
+
+Poi avviare normalmente:
+```bash
+docker-compose up -d
+```
+
 ### Deploy su rete privata
 
 Decommentare e modificare la sezione `environment` in `docker-compose.yml`:
@@ -664,7 +703,7 @@ docker build -t vibravid .
 docker run -d \
   --name vibravid \
   -p 8000:8000 \
-  -v vibravid_db:/app/GUI \
+  -v vibravid_db:/app/data \
   -v vibravid_videos:/app/Video \
   -v vibravid_logs:/app/logs \
   -v vibravid_config:/app/Conf \

--- a/README.md
+++ b/README.md
@@ -967,6 +967,45 @@ docker-compose logs -f      # View logs
 docker-compose down         # Stop (data persists)
 ```
 
+For NAS users (Synology, TrueNAS, Unraid, etc.), see **[docs/NAS.md](docs/NAS.md)** for a step-by-step setup guide including bind mounts and permission configuration.
+
+### Custom paths and ports
+
+Copy the provided template and edit the values you need:
+
+```bash
+cp .env.example .env
+```
+
+Key variables (full list in `.env.example`):
+
+| Variable | Default | Description |
+|---|---|---|
+| `VIBRAVID_PORT` | `8000` | Host port exposed by the container |
+| `VIBRAVID_VIDEO_DIR` | named volume | Where downloads land on the host (e.g. `/volume2/Movies`) |
+| `VIBRAVID_DB_DIR` | named volume | Host path for the SQLite database |
+| `VIBRAVID_CONFIG_DIR` | named volume | Host path for `config.json` / `login.json` |
+| `VIBRAVID_LOGS_DIR` | named volume | Host path for application logs |
+| `ALLOWED_HOSTS` | `localhost,127.0.0.1` | Comma-separated hostnames Django accepts |
+| `CSRF_TRUSTED_ORIGINS` | `http://localhost:8000,...` | Origins for CSRF validation |
+
+**NAS example** — store downloads on a NAS share, expose on port 9000:
+
+```env
+VIBRAVID_PORT=9000
+VIBRAVID_VIDEO_DIR=/volume2/Movies
+VIBRAVID_DB_DIR=/volume1/docker/vibravid/db
+VIBRAVID_CONFIG_DIR=/volume1/docker/vibravid/conf
+VIBRAVID_LOGS_DIR=/volume1/docker/vibravid/logs
+ALLOWED_HOSTS=localhost,127.0.0.1,192.168.1.100
+CSRF_TRUSTED_ORIGINS=http://192.168.1.100:9000
+```
+
+Then start normally:
+```bash
+docker-compose up -d
+```
+
 ### Private Network Deployment
 
 Uncomment and edit the `environment` section in `docker-compose.yml`:
@@ -1006,7 +1045,7 @@ docker build -t vibravid .
 docker run -d \
   --name vibravid \
   -p 8000:8000 \
-  -v vibravid_db:/app/GUI \
+  -v vibravid_db:/app/data \
   -v vibravid_videos:/app/Video \
   -v vibravid_logs:/app/logs \
   -v vibravid_config:/app/Conf \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,29 +5,30 @@ services:
     build:
       context: .
       dockerfile: dockerfile
-    container_name: vibravid
-    
+    container_name: ${VIBRAVID_CONTAINER_NAME:-vibravid}
+
     ### Networking
     ports:
-      - "8000:8000"
+      - "${VIBRAVID_PORT:-8000}:8000"
     # Uncomment for custom DNS (e.g., Cloudflare DNS)
     # dns:
     #   - 1.1.1.1
     #   - 8.8.8.8
     networks:
       - vibravid_network
-    
+
     ### Volumes - Persistent Data
     volumes:
-      # SQLite DB + any future per-install state (isolated dir, does NOT overlay app code)
-      - vibravid_db:/app/data
-      # Downloads persistence (named volume; override locally with a bind mount
-      # in docker-compose.override.yml if you want the files visible on the host)
-      - vibravid_videos:/app/Video
+      # SQLite DB + any future per-install state (isolated dir, does NOT overlay app code).
+      # Override with a host path via VIBRAVID_DB_DIR in .env (e.g. /volume1/docker/vibravid/db).
+      - ${VIBRAVID_DB_DIR:-vibravid_db}:/app/data
+      # Downloads. Override with a host path via VIBRAVID_VIDEO_DIR to store files on bulk storage
+      # (e.g. /volume2/Movies on a NAS). Named volume used when variable is not set.
+      - ${VIBRAVID_VIDEO_DIR:-vibravid_videos}:/app/Video
       # Logs persistence
-      - vibravid_logs:/app/logs
+      - ${VIBRAVID_LOGS_DIR:-vibravid_logs}:/app/logs
       # Configuration persistence
-      - vibravid_config:/app/Conf
+      - ${VIBRAVID_CONFIG_DIR:-vibravid_config}:/app/Conf
       # NOTE: /app/VibraVid/services is INTENTIONALLY NOT a named volume.
       # If it were, the volume would freeze the services directory to the
       # snapshot captured the first time the container started, and any
@@ -44,19 +45,17 @@ services:
       DJANGO_SECRET_KEY: "change-me-to-a-secure-key"
       PYTHONUNBUFFERED: "1"
       PYTHONPATH: "/app:${PYTHONPATH}"
-      
-      # Host Configuration
-      ALLOWED_HOSTS: "localhost,127.0.0.1"
-      CSRF_TRUSTED_ORIGINS: "http://localhost:8000,http://127.0.0.1:8000"
-      
+
+      # Host Configuration — override via .env or environment variables
+      ALLOWED_HOSTS: "${ALLOWED_HOSTS:-localhost,127.0.0.1}"
+      CSRF_TRUSTED_ORIGINS: "${CSRF_TRUSTED_ORIGINS:-http://localhost:8000,http://127.0.0.1:8000}"
+
       # Uncomment for private network deployment (behind reverse proxy)
-      # ALLOWED_HOSTS: "streaming.example.local,localhost,127.0.0.1,192.168.1.50"
-      # CSRF_TRUSTED_ORIGINS: "https://streaming.example.local"
       # USE_X_FORWARDED_HOST: "true"
       # SECURE_PROXY_SSL_HEADER_ENABLED: "true"
       # CSRF_COOKIE_SECURE: "true"
       # SESSION_COOKIE_SECURE: "true"
-      
+
       # Optional: Watchlist Auto-Download Interval (seconds)
       # WATCHLIST_AUTO_INTERVAL_SECONDS: "14400"
 
@@ -71,10 +70,10 @@ services:
       # RADARR_URL: "http://radarr:7878"
       # RADARR_API_KEY: ""
       # SEERR_WEBHOOK_SECRET: ""
-    
+
     ### Restart Policy
     restart: unless-stopped
-    
+
     ### Resource Limits (optional)
     # deploy:
     #   resources:
@@ -86,6 +85,9 @@ services:
     #       memory: 1G
 
 ### Persistent Named Volumes
+# These are only created when the corresponding VIBRAVID_*_DIR variable is NOT set to a host
+# path. If you override a variable with a host path (e.g. VIBRAVID_VIDEO_DIR=/mnt/nas/movies),
+# Docker uses a bind mount and the named volume below is NOT created.
 volumes:
   vibravid_db:
     driver: local


### PR DESCRIPTION
## Summary

  - All configurable values in `docker-compose.yml` (port, container name, volume paths, `ALLOWED_HOSTS`,
  `CSRF_TRUSTED_ORIGINS`) are now driven by environment variables with `${VAR:-default}` syntax
  - Added `.env.example` documenting every variable with comments and NAS-oriented examples (external drives,
  custom ports, LAN IP)
  - Added `.env` to `.gitignore`
  - Updated README (EN + IT) with a "Custom paths and ports" subsection

  ## Motivation

  NAS and home server users need to bind-mount host directories for downloads, configure the LAN IP in
  `ALLOWED_HOSTS`, and change the port — all without editing `docker-compose.yml` directly. A single `.env` file
   is the standard Docker Compose pattern for this.

  ## Backward compatibility

  **Zero breaking change.** Without a `.env` file, Compose falls back to the inline defaults, which recreate the
   exact same named volumes and port 8000 as today.

  ## Test plan

  - [ ] `docker compose config` without `.env` → output identical to current (named volumes, port 8000)
  - [ ] With `.env` setting `VIBRAVID_PORT=9000` and `VIBRAVID_VIDEO_DIR=/tmp/test` → `docker compose config`
  shows substitution; container starts on 9000

  Relates to #591