### PR TITLE
feat(update): in-app update banner + one-click host-side updater

### DIFF
--- a/GUI/searchapp/templates/searchapp/base.html
+++ b/GUI/searchapp/templates/searchapp/base.html
@@ -413,6 +413,68 @@
 			</div>
 		</nav>
 
+		<!-- Update banner — shown when a newer version is available on GitHub -->
+		<div id="update-banner" class="hidden fixed top-[var(--navbar-height)] left-0 right-0 z-40 bg-blue-700 text-white text-sm px-4 py-2 flex items-center justify-between gap-3">
+			<span id="update-banner-text"></span>
+			<div class="flex items-center gap-3 flex-shrink-0">
+				<a id="update-release-link" href="#" target="_blank" rel="noopener" class="underline font-medium hover:text-blue-100">Release notes</a>
+				<button id="update-trigger-btn" class="bg-white text-blue-700 font-semibold px-3 py-1 rounded hover:bg-blue-50 transition-colors">Update now</button>
+				<button onclick="dismissUpdateBanner()" class="text-blue-200 hover:text-white transition-colors" aria-label="Dismiss">&times;</button>
+			</div>
+		</div>
+		<script>
+		(function() {
+			var DISMISS_KEY = 'vibravid_update_dismissed_v';
+			function dismissUpdateBanner() {
+				var banner = document.getElementById('update-banner');
+				if (banner) {
+					var ver = banner.dataset.latest || '';
+					localStorage.setItem(DISMISS_KEY + ver, '1');
+					banner.classList.add('hidden');
+				}
+			}
+			window.dismissUpdateBanner = dismissUpdateBanner;
+
+			fetch('/api/version/check/')
+				.then(function(r) { return r.ok ? r.json() : null; })
+				.then(function(data) {
+					if (!data || !data.update_available) return;
+					var dismissed = localStorage.getItem(DISMISS_KEY + data.latest);
+					if (dismissed) return;
+					var banner = document.getElementById('update-banner');
+					var text = document.getElementById('update-banner-text');
+					var link = document.getElementById('update-release-link');
+					var btn = document.getElementById('update-trigger-btn');
+					text.textContent = 'VibraVid ' + data.latest + ' is available (current: ' + data.current + ')';
+					if (link) link.href = data.html_url || '#';
+					banner.dataset.latest = data.latest;
+					banner.classList.remove('hidden');
+
+					btn.addEventListener('click', function() {
+						btn.disabled = true;
+						btn.textContent = 'Updating…';
+						fetch('/api/version/update/', {method: 'POST', headers: {'X-CSRFToken': getCookie('csrftoken')}})
+							.then(function(r) { return r.json(); })
+							.then(function(d) {
+								if (d.success) {
+									btn.textContent = 'Restarting…';
+									setTimeout(function() { location.reload(); }, 30000);
+								} else {
+									btn.textContent = 'Failed — update manually';
+								}
+							})
+							.catch(function() { btn.textContent = 'Failed — update manually'; });
+					});
+				})
+				.catch(function() {});
+
+			function getCookie(name) {
+				var v = document.cookie.match('(^|;) ?' + name + '=([^;]*)(;|$)');
+				return v ? v[2] : '';
+			}
+		})();
+		</script>
+
 		<!-- Main Content -->
 		<main class="relative min-h-screen pt-[var(--navbar-height)]">
 			<!-- Messages Toast -->

--- a/GUI/searchapp/urls.py
+++ b/GUI/searchapp/urls.py
@@ -44,4 +44,8 @@ urlpatterns = [
     path("api/arr/webhook/radarr/", views.radarr_webhook, name="radarr_webhook"),
     path("api/arr/status/", views.arr_status, name="arr_status"),
     path("api/arr/trigger-sync/", views.arr_trigger_sync, name="arr_trigger_sync"),
+
+    # In-app update
+    path("api/version/check/", views.check_updates, name="check_updates"),
+    path("api/version/update/", views.trigger_update, name="trigger_update"),
 ]

--- a/GUI/searchapp/views.py
+++ b/GUI/searchapp/views.py
@@ -2049,3 +2049,67 @@ def reload_config(request: HttpRequest) -> JsonResponse:
             "success": False,
             "error": f"Errore nel reload: {str(e)}"
         }, status=500)
+
+
+# ── In-app update check ──────────────────────────────────────────────────────
+
+_update_check_cache: dict = {}  # {timestamp: float, result: dict}
+_UPDATE_CHECK_TTL = 3600  # re-fetch GitHub releases at most once per hour
+
+
+@require_http_methods(["GET"])
+def check_updates(request: HttpRequest) -> JsonResponse:
+    """Return current and latest version info, with a 1-hour in-memory cache."""
+    import urllib.request
+    from VibraVid.upload.version import __version__
+
+    cached = _update_check_cache
+    if cached and time.monotonic() - cached.get("ts", 0) < _UPDATE_CHECK_TTL:
+        return JsonResponse(cached["result"])
+
+    try:
+        api_url = "https://api.github.com/repos/AstraeLabs/VibraVid/releases/latest"
+        req = urllib.request.Request(api_url, headers={"User-Agent": "VibraVid-update-check/1"})
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            data = json.loads(resp.read())
+        latest = data.get("tag_name", "").lstrip("v")
+        html_url = data.get("html_url", "")
+    except Exception as exc:
+        logger.warning(f"Update check failed: {exc}")
+        return JsonResponse({"error": str(exc)}, status=502)
+
+    def _ver_tuple(v):
+        try:
+            return tuple(int(x) for x in v.split("."))
+        except Exception:
+            return (0,)
+
+    update_available = _ver_tuple(latest) > _ver_tuple(__version__)
+    result = {
+        "current": __version__,
+        "latest": latest,
+        "update_available": update_available,
+        "html_url": html_url,
+    }
+    _update_check_cache["ts"] = time.monotonic()
+    _update_check_cache["result"] = result
+    return JsonResponse(result)
+
+
+@require_http_methods(["POST"])
+def trigger_update(request: HttpRequest) -> JsonResponse:
+    """Write a sentinel file that a host-side update script can watch.
+
+    The container itself cannot run docker compose — it writes a marker file
+    to /app/data/.update_requested so an external script (scripts/nas-update.sh)
+    can detect it and perform the actual image pull + container recreation.
+    """
+    sentinel = os.path.join(os.environ.get("DJANGO_DB_DIR", "/app/data"), ".update_requested")
+    try:
+        with open(sentinel, "w") as f:
+            f.write(str(time.time()))
+        logger.info(f"Update sentinel written: {sentinel}")
+        return JsonResponse({"success": True, "sentinel": sentinel})
+    except Exception as exc:
+        logger.error(f"Failed to write update sentinel: {exc}")
+        return JsonResponse({"success": False, "error": str(exc)}, status=500)

--- a/README.md
+++ b/README.md
@@ -1028,6 +1028,26 @@ docker run -d --name vibravid -p 8000:8000 `
   vibravid
 ```
 
+### Updating (Docker)
+
+When a new version is released, VibraVid shows an **update banner** in the web UI. Click **Update now** to trigger the update.
+
+The container cannot restart itself — it writes a marker file to `/app/data/.update_requested`. A host-side script (`scripts/nas-update.sh`) picks it up and runs:
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+To use the one-click update, install and start `scripts/nas-update.sh` on the host. See [scripts/README.md](scripts/README.md) for setup instructions (systemd, Synology Scheduled Task, cron).
+
+**Manual update** (works without the script):
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
 ---
 
 ## Known Issues

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,83 @@
+# VibraVid — Scripts
+
+Helper scripts for self-hosted / NAS deployments.
+
+---
+
+## nas-update.sh — Automatic image updater
+
+`nas-update.sh` watches for the sentinel file written by the in-app **"Update now"** button and performs a `docker compose pull` + container recreation automatically.
+
+### How it works
+
+1. The web UI calls `/api/version/update/` (POST).
+2. VibraVid writes a marker file to `/app/data/.update_requested` inside the container.
+3. `nas-update.sh` runs on the **host**, polls that file every 60 seconds, and runs `docker compose pull && docker compose up -d` when it appears.
+
+This avoids giving the container access to the Docker socket.
+
+### Configuration
+
+Edit the variables at the top of the script, or set them as environment variables before starting:
+
+| Variable | Default | Description |
+|---|---|---|
+| `VIBRAVID_COMPOSE_DIR` | `/volume1/docker/vibravid` | Directory containing `docker-compose.yml` |
+| `VIBRAVID_DB_HOST_DIR` | `/volume1/docker/vibravid/db` | Host path where the `vibravid_db` volume is mounted |
+
+### Installation
+
+#### systemd (generic Linux)
+
+```ini
+# /etc/systemd/system/vibravid-updater.service
+[Unit]
+Description=VibraVid auto-updater
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/vibravid-updater.sh
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+Environment=VIBRAVID_COMPOSE_DIR=/opt/vibravid
+Environment=VIBRAVID_DB_HOST_DIR=/opt/vibravid/db
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo cp scripts/nas-update.sh /usr/local/bin/vibravid-updater.sh
+sudo chmod +x /usr/local/bin/vibravid-updater.sh
+sudo systemctl daemon-reload
+sudo systemctl enable --now vibravid-updater
+```
+
+#### Synology Scheduled Task (DSM 7)
+
+1. In DSM, go to **Control Panel → Task Scheduler → Create → Triggered task → Boot-up**.
+2. Set **User** to `root`.
+3. Set **Command** to:
+   ```
+   VIBRAVID_COMPOSE_DIR=/volume1/docker/vibravid VIBRAVID_DB_HOST_DIR=/volume1/docker/vibravid/db /volume1/docker/vibravid/scripts/nas-update.sh >> /var/log/vibravid-updater.log 2>&1
+   ```
+4. Click **OK**.
+
+#### cron (any Linux)
+
+```bash
+# Add to root's crontab:
+@reboot VIBRAVID_COMPOSE_DIR=/opt/vibravid VIBRAVID_DB_HOST_DIR=/opt/vibravid/db /opt/vibravid/scripts/nas-update.sh >> /var/log/vibravid-updater.log 2>&1
+```
+
+### Manual update (without the script)
+
+```bash
+cd /path/to/vibravid
+docker compose pull
+docker compose up -d
+```

--- a/scripts/nas-update.sh
+++ b/scripts/nas-update.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+# nas-update.sh — host-side VibraVid auto-updater
+#
+# Watches for the sentinel file written by the in-app "Update now" button and
+# performs a docker compose pull + container recreation when it appears.
+#
+# Installation (choose one):
+#
+#   systemd (Linux):
+#     Copy to /usr/local/bin/vibravid-updater.sh, then create a unit file:
+#     See scripts/README.md for a ready-to-use unit example.
+#
+#   Synology Scheduled Task (DSM 7):
+#     Control Panel → Task Scheduler → Create → Triggered task → Boot-up
+#     User: root
+#     Command: /volume1/docker/vibravid/scripts/nas-update.sh
+#
+#   cron (any Linux):
+#     @reboot /path/to/scripts/nas-update.sh >> /var/log/vibravid-updater.log 2>&1
+#
+# ── Configuration ──────────────────────────────────────────────────────────────
+
+# Absolute path to the directory that holds docker-compose.yml
+COMPOSE_DIR="${VIBRAVID_COMPOSE_DIR:-/volume1/docker/vibravid}"
+
+# Path on the HOST where the vibravid_db volume is mounted.
+# The in-app updater writes the sentinel file to /app/data inside the container;
+# set this to the corresponding host path so this script can find it.
+DB_HOST_DIR="${VIBRAVID_DB_HOST_DIR:-/volume1/docker/vibravid/db}"
+
+# Name of the sentinel file (must match views.trigger_update)
+SENTINEL="${DB_HOST_DIR}/.update_requested"
+
+# Lock file — prevents concurrent update runs
+LOCK="/tmp/vibravid-updater.lock"
+
+# Polling interval in seconds
+INTERVAL=60
+
+# ── Main loop ─────────────────────────────────────────────────────────────────
+
+echo "[vibravid-updater] Started. Watching ${SENTINEL} (poll every ${INTERVAL}s)"
+
+while true; do
+    if [ -f "$SENTINEL" ]; then
+        # Acquire lock
+        if [ -f "$LOCK" ]; then
+            echo "[vibravid-updater] Update already running, skipping."
+            sleep "$INTERVAL"
+            continue
+        fi
+        touch "$LOCK"
+
+        echo "[vibravid-updater] Sentinel found — pulling latest image and recreating container..."
+        rm -f "$SENTINEL"
+
+        cd "$COMPOSE_DIR" || { echo "[vibravid-updater] ERROR: COMPOSE_DIR not found: $COMPOSE_DIR"; rm -f "$LOCK"; sleep "$INTERVAL"; continue; }
+
+        docker compose pull && \
+            docker compose up -d --remove-orphans && \
+            echo "[vibravid-updater] Update complete." || \
+            echo "[vibravid-updater] ERROR: docker compose failed."
+
+        rm -f "$LOCK"
+    fi
+    sleep "$INTERVAL"
+done


### PR DESCRIPTION
## Summary

  - Added `GET /api/version/check/`: fetches latest release from GitHub API, compares with `__version__`,
  returns JSON `{current, latest, update_available, html_url}`. Result cached in memory for 1 hour.
  - Added `POST /api/version/update/`: writes a sentinel file `/app/data/.update_requested` (timestamp). No
  shell exec from Django — the container never touches the Docker socket.
  - Added update banner to `base.html`: appears on page load if `update_available`, dismissible per-version via
  localStorage, "Update now" button with 30 s graceful fallback message.
  - Added `scripts/nas-update.sh`: host-side polling script (60 s loop) that runs `docker compose pull && up -d`
   when the sentinel is detected. Includes lockfile and configurable paths.
  - Added `scripts/README.md`: setup instructions for systemd, Synology Scheduled Task, and cron.
  - Updated README (EN + IT) with "Updating (Docker)" section.

  ## Motivation

  There is currently no in-app way to know a new version is available or to trigger an update. NAS users in
  particular have no convenient update path. This PR adds a low-privilege update flow: the web UI signals intent
   via a file; a small host-side script handles the actual `docker compose` call.

  ## Security

  - `trigger_update` is protected by Django's CSRF middleware and the existing login requirement
  - The container writes only to its own `/app/data` volume — no Docker socket, no shell exec
  - The host script runs with whatever privileges the NAS user has (not elevated beyond what `docker compose`
  requires)

  ## Backward compatibility

  - Without `nas-update.sh` installed: the banner still shows and the user can follow the manual update
  instructions displayed next to the button
  - Existing installs: no change unless the new endpoints are called

  ## Test plan

  - [ ] Banner appears when `__version__` < latest GitHub release tag
  - [ ] Dismiss stores version in localStorage; does not re-appear on reload
  - [ ] "Update now" POST creates `/app/data/.update_requested` with timestamp
  - [ ] With `nas-update.sh` running: container is recreated within 60 s
  - [ ] Without script: graceful fallback message shown after 30 s