### PR TITLE
Fix ARR provider fallback, output path mapping, and AnimeUnity season handling

### DIFF
--- a/GUI/searchapp/api/animeunity.py
+++ b/GUI/searchapp/api/animeunity.py
@@ -122,6 +122,8 @@ class AnimeUnityAPI(BaseStreamingAPI):
         selections = None
         if is_series_like:
             selections = {'episode': episodes or '*'}
+            if season:
+                selections['season'] = season
         
         scrape_serie = self.get_cached_scraper(media_item)
         search_fn(direct_item=media_item.raw_data, selections=selections, scrape_serie=scrape_serie)

--- a/GUI/searchapp/arr/arr_service.py
+++ b/GUI/searchapp/arr/arr_service.py
@@ -152,6 +152,23 @@ def _build_clients(cfg: dict):
     return sonarr, radarr
 
 
+def _extract_provider_from_tags(client, tag_ids: list) -> str:
+    """Return provider override from provider-<service> tags, or empty for config order."""
+    if not client or not tag_ids:
+        return ""
+    try:
+        tags_map = client.get_tags_map()
+    except Exception as exc:
+        logger.warning(f"Could not read ARR tags map for provider selection: {exc}")
+        return ""
+
+    for tag_id in tag_ids:
+        label = (tags_map.get(tag_id, "") or "").strip().lower()
+        if label.startswith("provider-"):
+            return label.replace("provider-", "", 1).strip()
+    return ""
+
+
 def _dedup_key(item: dict, season_num: Optional[int] = None, ep_num: Optional[int] = None) -> str:
     """Build a dedup key for an ARR item."""
     content_type = item.get("content_type", "unknown")
@@ -226,7 +243,7 @@ def _enqueue_if_new(item: dict, sync_source: str, season_num: Optional[int] = No
                     episode_number=ep_num,
                     episode_id=episode_id,
                     year=item.get("year"),
-                    provider=item.get("provider", "streamingcommunity"),
+                    provider=item.get("provider", ""),
                     status=ArrMediaRequest.Status.PENDING,
                     sync_source=sync_source,
                     tmdb_id=str(item.get("tmdbId", "")) or None,
@@ -523,12 +540,7 @@ def trigger_webhook_sync(event_data: dict) -> int:
             logger.info(f"[trigger_webhook_sync] Movie '{matched['title']}' on hold/pause, skipping webhook")
             return -1  # signal to stop retrying
 
-        # Extract provider from tags
-        provider = "streamingcommunity"
-        for t_name in tag_names:
-            if t_name.startswith("provider-"):
-                provider = t_name.replace("provider-", "").strip()
-                break
+        provider = _extract_provider_from_tags(radarr, matched.get("tags", []))
         logger.info(f"[trigger_webhook_sync] Using provider: {provider}")
 
         item = {
@@ -641,7 +653,7 @@ def trigger_webhook_sync(event_data: dict) -> int:
             "path": matched.get("path", ""),
             "tags": matched.get("tags", []),
             "tmdbId": matched.get("tmdbId"),
-            "provider": "streamingcommunity",
+            "provider": _extract_provider_from_tags(sonarr, matched.get("tags", [])),
         }
 
         if not processor._check_tags_validity(serie_item["title"], serie_item["tags"]):
@@ -770,7 +782,7 @@ def trigger_sonarr_webhook_sync(event_data: dict) -> int:
         "path": series.get("path", ""),
         "tags": series.get("tags", []),
         "tmdbId": series.get("tmdbId"),
-        "provider": "streamingcommunity",
+        "provider": _extract_provider_from_tags(sonarr, series.get("tags", [])),
     }
 
     # Apply tag filtering
@@ -958,7 +970,7 @@ def trigger_radarr_webhook_sync(event_data: dict) -> int:
         "path": movie.get("path", ""),
         "tags": movie.get("tags", []),
         "tmdbId": movie.get("tmdbId"),
-        "provider": "streamingcommunity",
+        "provider": _extract_provider_from_tags(radarr, movie.get("tags", [])),
     }
 
     # Apply tag filtering

--- a/GUI/searchapp/arr/downloader_service.py
+++ b/GUI/searchapp/arr/downloader_service.py
@@ -104,14 +104,18 @@ class ArrDownloaderService:
                 target_folder = str(pathlib.Path(series_root).joinpath(f"S{season_num:02d}"))
                 logger.info(f"[S{season_num}E{ep_num}] Target folder (Sonarr's path): '{target_folder}'")
 
-                # Download directly to Sonarr's path
+                download_folder = self._translate_path(target_folder, reverse=True)
+                if download_folder != target_folder:
+                    logger.info(f"[S{season_num}E{ep_num}] Download folder (VibraVid path): '{download_folder}'")
+
+                # Download directly to VibraVid's equivalent path
                 future = _run_download_in_thread(
                     site=provider,
                     item_payload=item_payload,
                     season=str(season_num),
                     episodes=str(ep_num),
                     media_type="Serie",
-                    output_path=target_folder,
+                    output_path=download_folder,
                 )
                 any_success = True
 
@@ -226,13 +230,17 @@ class ArrDownloaderService:
             target_folder = self._fallback_movie_root(title)
         logger.info(f"[_process_movie] Target folder (Radarr's path): '{target_folder}'")
 
+        download_folder = self._translate_path(target_folder, reverse=True)
+        if download_folder != target_folder:
+            logger.info(f"[_process_movie] Download folder (VibraVid path): '{download_folder}'")
+
         future = _run_download_in_thread(
             site=provider,
             item_payload=item_payload,
             season=None,
             episodes=None,
             media_type="Film",
-            output_path=target_folder,
+            output_path=download_folder,
         )
 
         try:
@@ -299,8 +307,8 @@ class ArrDownloaderService:
     # ── helpers ──────────────────────────────────────────
 
     @staticmethod
-    def _translate_path(path: str) -> str:
-        """Translate a VibraVid host path to the equivalent path inside Radarr/Sonarr Docker containers.
+    def _translate_path(path: str, reverse: bool = False) -> str:
+        """Translate paths between VibraVid and Radarr/Sonarr Docker containers.
 
         Reads path_mapping from ARR config. Each entry maps a host prefix to a container prefix.
         Example: {"/media/Media/Film": "/media/Film"}
@@ -310,14 +318,23 @@ class ArrDownloaderService:
         conf_path = pathlib.Path(__file__).parent.parent.parent.parent / "Conf" / "config.json"
         try:
             with open(conf_path, encoding="utf-8") as _f:
-                mapping: dict = json.load(_f).get("ARR", {}).get("path_mapping", {})
+                mapping = json.load(_f).get("ARR", {}).get("path_mapping", {})
+                if not isinstance(mapping, dict):
+                    return path
         except Exception:
             return path
-        for host_prefix, container_prefix in mapping.items():
-            if path.startswith(host_prefix):
-                translated = container_prefix + path[len(host_prefix):]
+
+        sort_index = 1 if reverse else 0
+        for host_prefix, container_prefix in sorted(mapping.items(), key=lambda item: len(item[sort_index]), reverse=True):
+            source_prefix, target_prefix = (container_prefix, host_prefix) if reverse else (host_prefix, container_prefix)
+            source_prefix = source_prefix.rstrip("/\\")
+            target_prefix = target_prefix.rstrip("/\\")
+            if path == source_prefix or path.startswith(source_prefix + "/") or path.startswith(source_prefix + "\\"):
+                translated = target_prefix + path[len(source_prefix):]
                 logger.info(f"[path_map] '{path}' → '{translated}'")
                 return translated
+        if reverse:
+            logger.info(f"[path_map] No reverse mapping matched '{path}', leaving it unchanged")
         return path
 
     @staticmethod

--- a/GUI/searchapp/arr/downloader_service.py
+++ b/GUI/searchapp/arr/downloader_service.py
@@ -50,7 +50,7 @@ class ArrDownloaderService:
 
         title = serie["title"]
         series_id = serie.get("id")
-        provider = serie.get("provider", "streamingcommunity")
+        provider = (serie.get("provider") or "").strip()
         any_success = False
 
         # Resolve original title from Sonarr or TMDB
@@ -79,7 +79,7 @@ class ArrDownloaderService:
                     continue
 
                 display_title = f"{search_title} - S{season_num} E{ep_num}"
-                logger.info(f"⏳ Downloading '{display_title}' via {provider}")
+                logger.info(f"⏳ Downloading '{display_title}' via {provider or 'configured fallback order'}")
 
                 item_payload, provider = self._search_with_fallback(
                     search_title, provider,
@@ -88,6 +88,7 @@ class ArrDownloaderService:
                     expected_year=year,
                     tmdb_id=serie.get("tmdbId"),
                     media_type="tv",
+                    season_number=season_num,
                 )
                 if not item_payload:
                     logger.error(f"✖️ Could not find '{search_title}' on any provider")
@@ -124,19 +125,11 @@ class ArrDownloaderService:
                         series_root = self._fallback_series_root(title)
                     logger.info(f"[S{season_num}E{ep_num}] Using series root path: '{series_root}'")
 
-                    # Get the EXACT title and year that the website returned, because VibraVid saves using those
-                    result_name = item_payload.get("name", search_title)
-                    result_year = item_payload.get("year", year)
-                    
-                    # VibraVid's actual output folder (from Sonarr's perspective)
-                    vibrativo_folder = self._get_vibrativo_serie_output(series_root, result_name, season_num, result_year)
-
                     # Rescan series on the new path
                     try:
                         self.sonarr.command_rescan_series(serie["id"])
                         time.sleep(1)
-                        if vibrativo_folder:
-                            self.sonarr.command_downloaded_episodes_scan(self._translate_path(vibrativo_folder))
+                        self.sonarr.command_downloaded_episodes_scan(self._translate_path(target_folder))
                         logger.info(f"Rescan/import scan completed for S{season_num}E{ep_num}")
                     except Exception as scan_exc:
                         logger.warning(f"Rescan failed: {scan_exc}")
@@ -152,6 +145,29 @@ class ArrDownloaderService:
                         except Exception as exc:
                             logger.warning(f"Failed to verify Sonarr episode import: {exc}")
                         time.sleep(5)
+                    if not imported:
+                        result_name = item_payload.get("name", search_title)
+                        result_year = item_payload.get("year", year)
+                        fallback_folder = self._get_vibrativo_serie_output(series_root, result_name, season_num, result_year)
+                        if fallback_folder and fallback_folder != target_folder:
+                            logger.warning(
+                                f"S{season_num}E{ep_num} import not confirmed from '{target_folder}', "
+                                f"trying fallback scan path '{fallback_folder}'"
+                            )
+                            try:
+                                self.sonarr.command_downloaded_episodes_scan(self._translate_path(fallback_folder))
+                            except Exception as fallback_scan_exc:
+                                logger.warning(f"Fallback rescan failed: {fallback_scan_exc}")
+                            for _ in range(12):
+                                try:
+                                    episode = self.sonarr.get_episode(ep_id)
+                                    if episode.get("hasFile") or episode.get("episodeFileId"):
+                                        imported = True
+                                        break
+                                except Exception as exc:
+                                    logger.warning(f"Failed to verify Sonarr episode import after fallback scan: {exc}")
+                                time.sleep(5)
+
                     if not imported:
                         logger.error(f"S{season_num}E{ep_num} import not confirmed in Sonarr")
                         self.last_error = "import_not_confirmed"
@@ -176,7 +192,7 @@ class ArrDownloaderService:
         title = movie["title"]
         movie_id = movie["id"]
         tmdb_id = movie.get("tmdbId")
-        provider = movie.get("provider", "streamingcommunity")
+        provider = (movie.get("provider") or "").strip()
 
         if self.radarr.is_movie_in_queue(movie_id):
             logger.info(f"'{title}' already in Radarr queue, skipping")
@@ -189,7 +205,7 @@ class ArrDownloaderService:
         year = movie.get("year")
         year_range = self._build_year_range(year)
 
-        logger.info(f"⏳ Downloading movie '{search_title}' ({year}) via {provider}")
+        logger.info(f"⏳ Downloading movie '{search_title}' ({year}) via {provider or 'configured fallback order'}")
 
         item_payload, provider = self._search_with_fallback(
             search_title, provider,
@@ -223,88 +239,15 @@ class ArrDownloaderService:
             future.result(timeout=7200)  # wait for download to actually finish
             time.sleep(2)
 
-            # Get movie root path for manual import
-            movie_root = movie.get("path", "")
-            if not movie_root:
-                movie_root = self._fallback_movie_root(title)
-
-            # Get the EXACT title, year and slug that the website returned
             result_name = item_payload.get("name", search_title)
             result_year = item_payload.get("year", year)
-            result_slug = (item_payload.get("slug", "") or "").strip()
-
-            # For providers that name folders by slug (animeunity, animeworld),
-            # _get_vibrativo_movie_output would compute the wrong path.
-            # We search for the slug folder instead — read-only, no permission issues.
-            _anime_providers = {"animeunity", "animeworld"}
-            if provider in _anime_providers and result_slug:
-                _conf_path = pathlib.Path(__file__).parent.parent.parent.parent / "Conf" / "config.json"
-                try:
-                    with open(_conf_path, encoding="utf-8") as _f:
-                        _full_cfg = json.load(_f)
-                    _base = _full_cfg.get("OUTPUT", {}).get("root_path", "")
-                    _movie_dir = _full_cfg.get("OUTPUT", {}).get("movie_folder_name", "Film")
-                    _anime_dir = _full_cfg.get("OUTPUT", {}).get("anime_folder_name", "Anime")
-                    _ext = _full_cfg.get("PROCESS", {}).get("extension", "mkv")
-                except Exception:
-                    _base, _movie_dir, _anime_dir, _ext = "", "Film", "Anime", "mkv"
-
-                _candidates = [
-                    pathlib.Path(_base) / _movie_dir / result_slug,
-                    pathlib.Path(_base) / _anime_dir / result_slug,
-                    pathlib.Path(_base) / result_slug,
-                    pathlib.Path(movie_root).parent / result_slug if movie_root else None,
-                ]
-                found_dir = None
-                for _cand in _candidates:
-                    if _cand is None:
-                        continue
-                    if (_cand / f"{result_slug}.{_ext}").exists():
-                        found_dir = _cand
-                        logger.info(f"[anime_path] Slug folder found: '{_cand}'")
-                        break
-
-                if found_dir:
-                    import re as _re
-                    # Build clean name from result_name: strip lang tags + accents
-                    _lang_stripped = _re.sub(
-                        r'\s*\((?:ITA|ENG|SUB|DUB|DUAL|JAP|JP|IT|EN|FR|DE|ES)\)\s*$',
-                        '', result_name, flags=_re.IGNORECASE
-                    ).strip()
-                    _clean = self._strip_accents(_lang_stripped).strip()
-                    _yr = year or result_year
-                    _yr_str = str(_yr).split("-")[0].strip() if _yr else ""
-                    _clean_folder = f"{_clean} ({_yr_str})" if _yr_str else _clean
-
-                    _new_dir = found_dir.parent / _clean_folder
-                    _old_file = found_dir / f"{result_slug}.{_ext}"
-                    _new_file = _new_dir / f"{_clean_folder}.{_ext}"
-
-                    if not _new_dir.exists() and _old_file.exists():
-                        try:
-                            found_dir.rename(_new_dir)
-                            (_new_dir / f"{result_slug}.{_ext}").rename(_new_file)
-                            logger.info(f"[anime_path] Renamed '{found_dir.name}' → '{_new_dir.name}'")
-                            vibrativo_folder = str(_new_dir)
-                        except Exception as _rename_exc:
-                            logger.warning(f"[anime_path] Rename failed: {_rename_exc}, using slug folder")
-                            vibrativo_folder = str(found_dir)
-                    elif _new_dir.exists():
-                        vibrativo_folder = str(_new_dir)
-                    else:
-                        vibrativo_folder = str(found_dir)
-                else:
-                    vibrativo_folder = ""
-                    logger.warning(f"[anime_path] Slug folder not found for '{result_slug}'")
-            else:
-                vibrativo_folder = self._get_vibrativo_movie_output(movie_root, result_name, result_year)
+            fallback_folder = self._get_vibrativo_movie_output(target_folder, result_name, result_year)
 
             # Rescan movie on the new path
             try:
                 self.radarr.command_rescan_movie(movie_id)
                 time.sleep(1)
-                if vibrativo_folder:
-                    self.radarr.command_downloaded_movies_scan(self._translate_path(vibrativo_folder))
+                self.radarr.command_downloaded_movies_scan(self._translate_path(target_folder))
                 logger.info(f"Rescan/import scan completed for '{title}'")
             except Exception as scan_exc:
                 logger.warning(f"Rescan failed: {scan_exc}")
@@ -320,6 +263,26 @@ class ArrDownloaderService:
                 except Exception as exc:
                     logger.warning(f"Failed to verify Radarr movie import: {exc}")
                 time.sleep(5)
+            if not imported:
+                if fallback_folder and fallback_folder != target_folder:
+                    logger.warning(
+                        f"Movie '{title}' import not confirmed from '{target_folder}', "
+                        f"trying fallback scan path '{fallback_folder}'"
+                    )
+                    try:
+                        self.radarr.command_downloaded_movies_scan(self._translate_path(fallback_folder))
+                    except Exception as fallback_scan_exc:
+                        logger.warning(f"Fallback movie rescan failed: {fallback_scan_exc}")
+                    for _ in range(24):
+                        try:
+                            movie_obj = self.radarr.get_movie_by_id(movie_id)
+                            if movie_obj.get("hasFile") or movie_obj.get("movieFileId"):
+                                imported = True
+                                break
+                        except Exception as exc:
+                            logger.warning(f"Failed to verify Radarr movie import after fallback scan: {exc}")
+                        time.sleep(5)
+
             if not imported:
                 logger.error(f"Movie '{title}' import not confirmed in Radarr")
                 self.last_error = "import_not_confirmed"
@@ -390,7 +353,18 @@ class ArrDownloaderService:
         rw = sig_words(result_name)
         overlap = sw & rw
         ratio = len(overlap) / len(sw)
+        if len(sw) <= 2:
+            return ratio == 1.0
         return ratio >= 0.5
+
+    @staticmethod
+    def _normalize_title(title: str) -> str:
+        import re
+
+        title = ArrDownloaderService._strip_accents(title or "").lower()
+        title = re.sub(r"[^\w\s]", " ", title)
+        title = re.sub(r"\s+", " ", title).strip()
+        return title
 
     @staticmethod
     def _verify_title_match(result_name: str, expected_title: str,
@@ -438,19 +412,6 @@ class ArrDownloaderService:
 
         Returns (payload, used_provider). payload is None if nothing found anywhere.
         """
-        logger.info(f"[fallback] Search '{title}' — primary provider: {primary_provider}")
-
-        payload = self._search_and_build_payload(title, primary_provider, **kwargs)
-        if payload:
-            logger.info(
-                f"[fallback] Found on primary '{primary_provider}': "
-                f"name='{payload.get('name')}' year={payload.get('year')}"
-            )
-            logger.debug(f"[fallback] Payload dump: {json.dumps(payload, default=str, ensure_ascii=False)}")
-            return payload, primary_provider
-
-        logger.warning(f"[fallback] '{title}' not found on '{primary_provider}', trying fallback list")
-
         conf_path = pathlib.Path(__file__).parent.parent.parent.parent / "Conf" / "config.json"
         try:
             with open(conf_path, encoding="utf-8") as _f:
@@ -459,33 +420,37 @@ class ArrDownloaderService:
             logger.warning(f"[fallback] Could not read provider_fallback from config: {_exc}")
             fallback_list = []
 
-        if not fallback_list:
-            logger.warning("[fallback] provider_fallback not configured in ARR config — giving up")
-            return None, primary_provider
+        providers = []
+        if primary_provider:
+            providers.append(primary_provider)
+        providers.extend(provider for provider in fallback_list if provider and provider not in providers)
+        if not providers:
+            providers = ["streamingcommunity"]
 
-        for provider in fallback_list:
-            if provider == primary_provider:
-                continue
+        logger.info(f"[fallback] Search '{title}' — provider order: {providers}")
+        for index, provider in enumerate(providers):
+            label = "primary" if index == 0 else "fallback"
             logger.info(f"[fallback] Trying '{provider}' for '{title}'")
             payload = self._search_and_build_payload(title, provider, **kwargs)
             if payload:
                 logger.info(
-                    f"[fallback] Found on fallback '{provider}': "
+                    f"[fallback] Found on {label} '{provider}': "
                     f"name='{payload.get('name')}' year={payload.get('year')}"
                 )
                 logger.debug(f"[fallback] Payload dump: {json.dumps(payload, default=str, ensure_ascii=False)}")
                 return payload, provider
             logger.warning(f"[fallback] '{title}' not found on '{provider}' either")
 
-        logger.error(f"[fallback] '{title}' not found on any provider (tried: {primary_provider} + {fallback_list})")
-        return None, primary_provider
+        logger.error(f"[fallback] '{title}' not found on any provider (tried: {providers})")
+        return None, primary_provider or (providers[0] if providers else "")
 
     def _search_and_build_payload(self, title: str, provider: str,
                                   year_range: Optional[str] = None,
                                   expected_title: Optional[str] = None,
                                   expected_year: Optional[int] = None,
                                   tmdb_id: Optional[int] = None,
-                                  media_type: str = "tv") -> Optional[Dict[str, Any]]:
+                                  media_type: str = "tv",
+                                  season_number: Optional[int] = None) -> Optional[Dict[str, Any]]:
         """Search VibraVid's streaming API for a title and return an item_payload dict.
 
         Uses TMDB API to get alternative titles for verification when tmdb_id is provided.
@@ -501,12 +466,12 @@ class ArrDownloaderService:
             if tmdb_id:
                 try:
                     from VibraVid.provider.tmdb import tmdb_client as tmdb
-                    
+
                     # Get titles in Italian (for streamingcommunity) and English
                     for lang in ["it", "en"]:
                         alt_titles = tmdb.get_alternative_titles(tmdb_id, media_type, lang)
                         tmdb_titles.extend(alt_titles)
-                    
+
                     # Deduplicate
                     tmdb_titles = list(set(t.strip() for t in tmdb_titles if t.strip()))
                     logger.info(f"TMDB alternative titles for {tmdb_id}: {tmdb_titles[:5]}")
@@ -549,10 +514,41 @@ class ArrDownloaderService:
             expected_tmdb_str = str(tmdb_id) if tmdb_id else ""
 
             best = None
+            if media_type == "tv" and provider in {"animeunity", "animeworld"} and season_number:
+                try:
+                    season_int = int(season_number)
+                except (TypeError, ValueError):
+                    season_int = 0
+                if season_int > 1:
+                    expected_season_title = self._normalize_title(f"{title} {season_int}")
+                    season_best = next(
+                        (
+                            r for r in results
+                            if self._normalize_title(r.name or "") == expected_season_title
+                        ),
+                        None,
+                    )
+                    if season_best:
+                        best = season_best
+                        logger.info(
+                            f"[search] ACCEPT '{season_best.name}' — "
+                            f"season-specific anime match for S{season_int}"
+                        )
+
             for r in results:
+                if best is not None:
+                    break
                 r_name = r.name or ""
                 r_year = r.year or ""
                 r_tmdb = str(getattr(r, 'tmdb_id', '') or '')
+                r_type = str(getattr(r, 'type', '') or '').lower()
+
+                if media_type == "tv" and r_type == "movie":
+                    logger.warning(
+                        f"[type_check] SKIP '{r_name}' ({r_year}) — "
+                        "movie result cannot satisfy a Sonarr TV request"
+                    )
+                    continue
 
                 # ── TMDB ID check (highest priority) ──────────────────────
                 if expected_tmdb_str and r_tmdb:
@@ -655,11 +651,26 @@ class ArrDownloaderService:
             except Exception:
                 _prefer_ita = True
 
+            season_int_for_ita = 0
+            try:
+                season_int_for_ita = int(season_number or 0)
+            except (TypeError, ValueError):
+                season_int_for_ita = 0
+
             if _prefer_ita and "(ITA)" not in (best.name or "").upper():
+                expected_season_title = (
+                    self._normalize_title(f"{title} {season_int_for_ita}")
+                    if media_type == "tv" and provider in {"animeunity", "animeworld"} and season_int_for_ita > 1
+                    else None
+                )
                 ita = next(
                     (r for r in results
                      if "(ITA)" in (r.name or "").upper()
-                     and self._titles_are_compatible(title, r.name or "")),
+                     and self._titles_are_compatible(title, r.name or "")
+                     and (
+                         expected_season_title is None
+                         or self._normalize_title((r.name or "").replace("(ITA)", "")) == expected_season_title
+                     )),
                     None,
                 )
                 if ita:
@@ -711,7 +722,7 @@ class ArrDownloaderService:
                 if it_title and it_title.lower() != title.lower():
                     logger.info(f"Using Italian title from TMDB: '{it_title}'")
                     return it_title
-                
+
             except Exception as tmdb_exc:
                 logger.debug(f"Failed to get Italian title from TMDB: {tmdb_exc}")
 
@@ -763,11 +774,11 @@ class ArrDownloaderService:
                     for lang in ["it", "en"]:
                         details = tmdb._make_request(f"movie/{tmdb_id}", {"language": lang})
                         loc_title = details.get("title", "")
-                        
+
                         if loc_title and loc_title != original:
                             logger.info(f"Non-ASCII original '{original}' → using {lang.upper()} TMDB title: '{loc_title}'")
                             return loc_title
-                        
+
                 except Exception as tmdb_exc:
                     logger.debug(f"TMDB localised title fallback failed: {tmdb_exc}")
 
@@ -806,20 +817,20 @@ class ArrDownloaderService:
         try:
             from VibraVid.services._base.tv_display_manager import map_episode_path
             import pathlib
-            
+
             # Pass the year as string if available to match VibraVid's exact logic
             series_year = str(year) if year else None
             path_components, _ = map_episode_path(series_name=search_title, series_year=series_year, season_number=season_num)
-            
+
             if "\\" in arr_series_path:
                 root = pathlib.PureWindowsPath(arr_series_path).parent
             else:
                 root = pathlib.PurePosixPath(arr_series_path).parent
-                
+
             # Append ONLY the series folder (path_components[0]), ignoring the season subfolder
             if path_components:
                 root = root / path_components[0]
-                
+
             return str(root)
         except Exception as exc:
             logger.debug(f"Could not compute VibraVid serie output path: {exc}")
@@ -832,16 +843,16 @@ class ArrDownloaderService:
         try:
             from VibraVid.services._base.tv_display_manager import map_movie_path
             import pathlib
-            
+
             # Pass the year as string if available
             title_year = str(year) if year else None
             path_components, _ = map_movie_path(title_name=search_title, title_year=title_year)
-            
+
             if "\\" in arr_movie_path:
                 root = pathlib.PureWindowsPath(arr_movie_path).parent
             else:
                 root = pathlib.PurePosixPath(arr_movie_path).parent
-                
+
             for part in path_components:
                 root = root / part.strip()  # strip trailing spaces from year-less format
             return str(root)
@@ -867,12 +878,12 @@ class ArrDownloaderService:
                     path = str(item.get("path", "")).strip()
                     if not path:
                         continue
-                    
+
                     # Sonarr v3 requires seriesId and episodeIds at root level for POST
                     ep_ids = [ep["id"] for ep in item.get("episodes", []) if "id" in ep]
                     if not ep_ids:
                         ep_ids = [episode_id]  # Fallback to the requested episode if not parsed
-                        
+
                     post_item = dict(item)
                     post_item["seriesId"] = series_id
                     post_item["episodeIds"] = ep_ids
@@ -915,11 +926,11 @@ class ArrDownloaderService:
                     path = str(item.get("path", "")).strip()
                     if not path:
                         continue
-                        
+
                     post_item = dict(item)
                     post_item["movieId"] = movie_id
                     import_payload.append(post_item)
-                    
+
                 if import_payload:
                     self.radarr.manual_import(import_payload)
                     logger.info(f"Manual import submitted for {len(import_payload)} file(s) from '{folder}'")

--- a/GUI/searchapp/arr/processor_service.py
+++ b/GUI/searchapp/arr/processor_service.py
@@ -197,4 +197,4 @@ class ArrProcessorService:
             label = tags_map.get(t_id, "")
             if label.startswith("provider-"):
                 return label.replace("provider-", "").strip()
-        return "streamingcommunity"
+        return ""

--- a/GUI/searchapp/views.py
+++ b/GUI/searchapp/views.py
@@ -448,8 +448,8 @@ def _run_download_in_thread(site: str, item_payload: Dict[str, Any], season: str
             context_tracker.media_type = media_type
             context_tracker.is_gui = True
             context_tracker.is_cancelled_callback = _is_scheduled_cancelled
-            context_tracker.season = season
-            context_tracker.episode = episodes
+            context_tracker.season = int(season) if str(season or "").isdigit() else 0
+            context_tracker.episode = int(episodes) if str(episodes or "").isdigit() else 0
 
             api = get_api(site)
 

--- a/GUI/searchapp/views.py
+++ b/GUI/searchapp/views.py
@@ -448,6 +448,8 @@ def _run_download_in_thread(site: str, item_payload: Dict[str, Any], season: str
             context_tracker.media_type = media_type
             context_tracker.is_gui = True
             context_tracker.is_cancelled_callback = _is_scheduled_cancelled
+            context_tracker.season = season
+            context_tracker.episode = episodes
 
             api = get_api(site)
 
@@ -488,6 +490,11 @@ def _run_download_in_thread(site: str, item_payload: Dict[str, Any], season: str
                 print(f"[Error] Failed to update download tracker: {tracker_err}")
             raise
         finally:
+            context_tracker.output_path = None
+            context_tracker.season = 0
+            context_tracker.episode = 0
+            context_tracker.episode_name = None
+            context_tracker.is_cancelled_callback = None
             _release_download_slot()
 
     return download_executor.submit(_task)

--- a/VibraVid/core/ui/tracker.py
+++ b/VibraVid/core/ui/tracker.py
@@ -430,6 +430,14 @@ class ContextTracker:
         self.local.episode_name = value
 
     @property
+    def output_path(self):
+        return getattr(self.local, 'output_path', None)
+
+    @output_path.setter
+    def output_path(self, value):
+        self.local.output_path = value
+
+    @property
     def should_print(self) -> bool:
         """Returns False when console output should be suppressed (parallel CLI or GUI)."""
         return not self.is_gui and not self.is_parallel_cli

--- a/VibraVid/services/_base/__init__.py
+++ b/VibraVid/services/_base/__init__.py
@@ -3,10 +3,15 @@
 from .site_costant import site_constants
 from .site_loader import load_search_functions
 from .object import EntriesManager, Entries
+from .output_path import movie_folder, series_folder, anime_folder, music_folder
 
 __all__ = [
     "site_constants",
     "load_search_functions",
     "EntriesManager",
-    "Entries"
+    "Entries",
+    "movie_folder",
+    "series_folder",
+    "anime_folder",
+    "music_folder",
 ]

--- a/VibraVid/services/_base/output_path.py
+++ b/VibraVid/services/_base/output_path.py
@@ -1,0 +1,28 @@
+import os
+
+from VibraVid.core.ui.tracker import context_tracker
+
+from .site_costant import site_constants
+
+
+def _resolve_folder(base_folder: str, *path_components: str) -> str:
+    forced_output = context_tracker.output_path
+    if forced_output:
+        return forced_output
+    return os.path.join(base_folder, *path_components) if path_components else base_folder
+
+
+def movie_folder(*path_components: str) -> str:
+    return _resolve_folder(site_constants.MOVIE_FOLDER, *path_components)
+
+
+def series_folder(*path_components: str) -> str:
+    return _resolve_folder(site_constants.SERIES_FOLDER, *path_components)
+
+
+def anime_folder(*path_components: str) -> str:
+    return _resolve_folder(site_constants.ANIME_FOLDER, *path_components)
+
+
+def music_folder(*path_components: str) -> str:
+    return _resolve_folder(site_constants.MUSIC_FOLDER, *path_components)

--- a/VibraVid/services/animeunity/downloader.py
+++ b/VibraVid/services/animeunity/downloader.py
@@ -6,8 +6,9 @@ from rich.console import Console
 from rich.prompt import Prompt
 
 from VibraVid.utils import os_manager, config_manager, start_message
-from VibraVid.services._base import site_constants, Entries
+from VibraVid.services._base import site_constants, Entries, movie_folder, anime_folder
 from VibraVid.services._base.tv_display_manager import manage_selection, map_episode_path, map_movie_path
+from VibraVid.core.ui.tracker import context_tracker
 
 from VibraVid.core.downloader import MP4_Downloader, HLS_Downloader
 
@@ -57,12 +58,17 @@ def download_episode(obj_episode, index_select, scrape_serie, video_source):
             episode_number = 1
         episode_name = f"Episode {obj_episode.number}"
 
-        path_components, filename = map_episode_path(series_name=scrape_serie.series_name, series_year=None, season_number=1, episode_number=episode_number, episode_name=episode_name)
-        mp4_path = os_manager.get_sanitize_path(os.path.join(site_constants.ANIME_FOLDER, *path_components))
+        season_number = getattr(context_tracker, "season", None) or 1
+        try:
+            season_number = int(season_number)
+        except (TypeError, ValueError):
+            season_number = 1
+        path_components, filename = map_episode_path(series_name=scrape_serie.series_name, series_year=None, season_number=season_number, episode_number=episode_number, episode_name=episode_name)
+        mp4_path = os_manager.get_sanitize_path(anime_folder(*path_components))
         mp4_name = filename
     else:
         path_components, filename = map_movie_path(scrape_serie.series_name, None)
-        mp4_path = os_manager.get_sanitize_path(os.path.join(site_constants.MOVIE_FOLDER, *path_components) if path_components else site_constants.MOVIE_FOLDER)
+        mp4_path = os_manager.get_sanitize_path(movie_folder(*path_components))
         mp4_name = filename
 
     # Create output folder

--- a/VibraVid/services/animeworld/downloader.py
+++ b/VibraVid/services/animeworld/downloader.py
@@ -6,7 +6,7 @@ from rich.console import Console
 from rich.prompt import Prompt
 
 from VibraVid.utils import os_manager, start_message
-from VibraVid.services._base import site_constants, Entries
+from VibraVid.services._base import site_constants, Entries, anime_folder
 from VibraVid.services._base.tv_display_manager import manage_selection, map_episode_path
 
 from VibraVid.core.downloader import MP4_Downloader
@@ -35,7 +35,7 @@ def download_film(select_title: Entries):
     # Define filename and path for the downloaded video
     serie_name_with_year = os_manager.get_sanitize_file(scrape_serie.get_name(), select_title.year)
     mp4_name = f"{serie_name_with_year}.mp4"
-    mp4_path = os.path.join(site_constants.ANIME_FOLDER, serie_name_with_year.replace('.mp4', ''))
+    mp4_path = anime_folder(serie_name_with_year.replace('.mp4', ''))
 
     # Create output folder
     os_manager.create_path(mp4_path)
@@ -64,7 +64,7 @@ def download_episode(episode_data, index_select, scrape_serie):
     console.print(f"\n[yellow]Download: [red]{site_constants.SITE_NAME} → [cyan]{series_name} ([cyan]E{episode_number}) \n")
 
     path_components, filename = map_episode_path(series_name=series_name, series_year=None, season_number=1, episode_number=episode_number, episode_name=episode_name)
-    episode_path = os.path.join(site_constants.ANIME_FOLDER, *path_components)
+    episode_path = anime_folder(*path_components)
     episode_filename = f"{filename}.mp4"
 
     # Create output folder

--- a/VibraVid/services/cinezo/downloader.py
+++ b/VibraVid/services/cinezo/downloader.py
@@ -7,7 +7,7 @@ import logging
 from rich.console import Console
 
 from VibraVid.utils import config_manager, start_message, os_manager
-from VibraVid.services._base import site_constants, Entries
+from VibraVid.services._base import site_constants, Entries, movie_folder, series_folder
 from VibraVid.services._base.tv_display_manager import map_movie_path, map_episode_path
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 from VibraVid.core.downloader import HLS_Downloader, MP4_Downloader
@@ -34,7 +34,7 @@ def download_film(select_title: Entries):
     console.print(f"[cyan]Stream: {m3u8_url[:70]}...\n")
 
     path_components, filename = map_movie_path(select_title.name, select_title.year)
-    out_dir = os_manager.get_sanitize_path(os.path.join(site_constants.MOVIE_FOLDER, *path_components) if path_components else site_constants.MOVIE_FOLDER)
+    out_dir = os_manager.get_sanitize_path(movie_folder(*path_components))
     out_path = os.path.join(out_dir, f"{filename}.{extension_output}")
 
     if "/mp4/" in m3u8_url:
@@ -71,8 +71,7 @@ def download_episode(obj_episode, index: int, scrape_serie: GetSerieInfo, season
         episode_number = int(obj_episode.number),
         episode_name = obj_episode.name,
     )
-    out_dir  = os_manager.get_sanitize_path(
-        os.path.join(site_constants.SERIES_FOLDER, *path_components))
+    out_dir  = os_manager.get_sanitize_path(series_folder(*path_components))
     out_path = os.path.join(out_dir, f"{filename}.{extension_output}")
 
     if "/mp4/" in m3u8_url:

--- a/VibraVid/services/crunchyroll/downloader.py
+++ b/VibraVid/services/crunchyroll/downloader.py
@@ -9,7 +9,7 @@ from rich.console import Console
 from rich.prompt import Prompt
 
 from VibraVid.utils import config_manager, os_manager, start_message
-from VibraVid.services._base import site_constants, Entries
+from VibraVid.services._base import site_constants, Entries, movie_folder, anime_folder
 from VibraVid.services._base.tv_display_manager import map_movie_path, map_episode_path
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 from VibraVid.core.utils.language import resolve_locale
@@ -138,7 +138,7 @@ def download_film(select_title: Entries) -> str:
 
     # Define filename and path
     path_components, filename = map_movie_path(select_title.name, select_title.year)
-    movie_path = os.path.join(site_constants.MOVIE_FOLDER, *path_components) if path_components else site_constants.MOVIE_FOLDER
+    movie_path = movie_folder(*path_components)
     movie_name = f"{filename}.{extension_output}"
 
     # Extract media ID
@@ -197,7 +197,7 @@ def download_episode(obj_episode, index_season_selected, index_episode_selected,
     console.print(f"\n[yellow]Download: [red]{site_constants.SITE_NAME} → [cyan]{scrape_serie.series_name} [white]\\ [magenta]{obj_episode.name} ([cyan]S{index_season_selected}E{index_episode_selected}) \n")
 
     path_components, filename = map_episode_path(scrape_serie.series_name, getattr(scrape_serie, 'year', None), index_season_selected, index_episode_selected, obj_episode.name)
-    title_path = os_manager.get_sanitize_path(os.path.join(site_constants.ANIME_FOLDER, *path_components))
+    title_path = os_manager.get_sanitize_path(anime_folder(*path_components))
     title_name = f"{filename}.{extension_output}"
 
     # Get media ID and main_guid

--- a/VibraVid/services/discovery/downloader.py
+++ b/VibraVid/services/discovery/downloader.py
@@ -6,7 +6,7 @@ from rich.console import Console
 from rich.prompt import Prompt
 
 from VibraVid.utils import config_manager, start_message
-from VibraVid.services._base import site_constants, Entries
+from VibraVid.services._base import site_constants, Entries, series_folder
 from VibraVid.services._base.tv_display_manager import map_episode_path
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 
@@ -30,7 +30,7 @@ def download_episode(obj_episode, index_season_selected, index_episode_selected,
 
     # Define filename and path for the downloaded video
     path_components, filename = map_episode_path(scrape_serie.series_name, getattr(scrape_serie, 'year', None), index_season_selected, index_episode_selected, obj_episode.name)
-    episode_path = os.path.join(site_constants.SERIES_FOLDER, *path_components)
+    episode_path = series_folder(*path_components)
     episode_name = f"{filename}.{extension_output}"
 
     # Get m3u8 playlist

--- a/VibraVid/services/discoveryplus/downloader.py
+++ b/VibraVid/services/discoveryplus/downloader.py
@@ -8,7 +8,7 @@ from rich.console import Console
 from rich.prompt import Prompt
 
 from VibraVid.utils import os_manager, config_manager, start_message
-from VibraVid.services._base import site_constants, Entries
+from VibraVid.services._base import site_constants, Entries, movie_folder, series_folder
 from VibraVid.services._base.tv_display_manager import map_episode_path, map_movie_path
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 
@@ -60,7 +60,7 @@ def download_live(select_title: Entries):
 
     # Reuse the movie path logic — live events are single-file downloads
     path_components, filename = map_movie_path(select_title.name, select_title.year)
-    live_path = os_manager.get_sanitize_path(os.path.join(site_constants.MOVIE_FOLDER, *path_components) if path_components else site_constants.MOVIE_FOLDER)
+    live_path = os_manager.get_sanitize_path(movie_folder(*path_components))
     live_name = f"{filename}.{extension_output}"
 
     client = get_client()
@@ -98,9 +98,7 @@ def download_film(select_title: Entries):
     
     # Define output path
     path_components, filename = map_movie_path(select_title.name, select_title.year)
-    movie_path = os_manager.get_sanitize_path(
-        os.path.join(site_constants.MOVIE_FOLDER, *path_components) if path_components else site_constants.MOVIE_FOLDER
-    )
+    movie_path = os_manager.get_sanitize_path(movie_folder(*path_components))
     movie_name = f"{filename}.{extension_output}"
     
     # Get playback info
@@ -126,7 +124,7 @@ def download_episode(obj_episode, index_season_selected, index_episode_selected,
 
     # Define output path
     path_components, filename = map_episode_path(scrape_serie.series_name,getattr(scrape_serie, 'year', None), index_season_selected, index_episode_selected, obj_episode.name)
-    episode_path = os_manager.get_sanitize_path(os.path.join(site_constants.SERIES_FOLDER, *path_components))
+    episode_path = os_manager.get_sanitize_path(series_folder(*path_components))
     episode_name = f"{filename}.{extension_output}"
 
     # Get playback info

--- a/VibraVid/services/dmax/downloader.py
+++ b/VibraVid/services/dmax/downloader.py
@@ -6,7 +6,7 @@ from rich.console import Console
 from rich.prompt import Prompt
 
 from VibraVid.utils import config_manager, start_message
-from VibraVid.services._base import site_constants, Entries
+from VibraVid.services._base import site_constants, Entries, series_folder
 from VibraVid.services._base.tv_display_manager import map_episode_path
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 
@@ -30,7 +30,7 @@ def download_episode(obj_episode, index_season_selected, index_episode_selected,
 
     # Define filename and path for the downloaded video
     path_components, filename = map_episode_path(scrape_serie.series_name, getattr(scrape_serie, 'year', None), index_season_selected, index_episode_selected, obj_episode.name)
-    episode_path = os.path.join(site_constants.SERIES_FOLDER, *path_components)
+    episode_path = series_folder(*path_components)
     episode_name = f"{filename}.{extension_output}"
 
     # Get m3u8 playlist

--- a/VibraVid/services/eurostreaming/downloader.py
+++ b/VibraVid/services/eurostreaming/downloader.py
@@ -7,7 +7,7 @@ import logging
 from rich.console import Console
 
 from VibraVid.utils import config_manager, start_message, os_manager
-from VibraVid.services._base import site_constants, Entries
+from VibraVid.services._base import site_constants, Entries, series_folder
 from VibraVid.services._base.tv_display_manager import map_episode_path
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 from VibraVid.core.downloader import HLS_Downloader
@@ -50,7 +50,7 @@ def _download_episode(obj_episode, season_number: int, episode_number: int, scra
         return None
 
     path_components, filename = map_episode_path(scrape_serie.series_display_name, scrape_serie.year, season_number, episode_number, obj_episode.name,)
-    out_dir = os_manager.get_sanitize_path(os.path.join(site_constants.SERIES_FOLDER, *path_components))
+    out_dir = os_manager.get_sanitize_path(series_folder(*path_components))
     out_path = os.path.join(out_dir, f"{filename}.{extension_output}")
 
     return HLS_Downloader(

--- a/VibraVid/services/foodnetwork/downloader.py
+++ b/VibraVid/services/foodnetwork/downloader.py
@@ -6,7 +6,7 @@ from rich.console import Console
 from rich.prompt import Prompt
 
 from VibraVid.utils import config_manager, start_message
-from VibraVid.services._base import site_constants, Entries
+from VibraVid.services._base import site_constants, Entries, series_folder
 from VibraVid.services._base.tv_display_manager import map_episode_path
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 
@@ -30,7 +30,7 @@ def download_episode(obj_episode, index_season_selected, index_episode_selected,
 
     # Define filename and path for the downloaded video
     path_components, filename = map_episode_path(scrape_serie.series_name, getattr(scrape_serie, 'year', None), index_season_selected, index_episode_selected, obj_episode.name)
-    episode_path = os.path.join(site_constants.SERIES_FOLDER, *path_components)
+    episode_path = series_folder(*path_components)
     episode_name = f"{filename}.{extension_output}"
 
     # Get m3u8 playlist

--- a/VibraVid/services/homegardentv/downloader.py
+++ b/VibraVid/services/homegardentv/downloader.py
@@ -6,7 +6,7 @@ from rich.console import Console
 from rich.prompt import Prompt
 
 from VibraVid.utils import config_manager, start_message
-from VibraVid.services._base import site_constants, Entries
+from VibraVid.services._base import site_constants, Entries, series_folder
 from VibraVid.services._base.tv_display_manager import map_episode_title, map_season_name, map_series_name
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 
@@ -31,7 +31,7 @@ def download_episode(obj_episode, index_season_selected, index_episode_selected,
 
     # Define filename and path for the downloaded video
     episode_name = f"{map_episode_title(scrape_serie.series_name, index_season_selected, index_episode_selected, obj_episode.name)}.{extension_output}"
-    episode_path = os.path.join(site_constants.SERIES_FOLDER, series_folder_name, map_season_name(index_season_selected))
+    episode_path = series_folder(series_folder_name, map_season_name(index_season_selected))
 
     # Get m3u8 playlist
     bearer_token = get_bearer_token()

--- a/VibraVid/services/mediasetinfinity/downloader.py
+++ b/VibraVid/services/mediasetinfinity/downloader.py
@@ -10,7 +10,7 @@ from rich.prompt import Prompt
 
 from VibraVid.utils import os_manager, config_manager, start_message
 from VibraVid.utils.http_client import create_client
-from VibraVid.services._base import site_constants, Entries
+from VibraVid.services._base import site_constants, Entries, movie_folder, series_folder
 from VibraVid.services._base.tv_display_manager import map_movie_path, map_episode_path
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 
@@ -109,7 +109,7 @@ def download_film(select_title: Entries) -> Tuple[str, bool]:
 
     # Define the filename and path for the downloaded film
     path_components, filename = map_movie_path(select_title.name, select_title.year)
-    movie_path = os.path.join(site_constants.MOVIE_FOLDER, *path_components) if path_components else site_constants.MOVIE_FOLDER
+    movie_path = movie_folder(*path_components)
     movie_name = f"{filename}.{extension_output}"
 
     # Get playback URL and tracking info
@@ -132,7 +132,7 @@ def download_episode(obj_episode, index_season_selected, index_episode_selected,
 
     # Define filename and path for the downloaded video
     path_components, filename = map_episode_path(scrape_serie.series_name, getattr(scrape_serie, 'year', None), index_season_selected, index_episode_selected, obj_episode.name)
-    episode_path = os_manager.get_sanitize_path(os.path.join(site_constants.SERIES_FOLDER, *path_components))
+    episode_path = os_manager.get_sanitize_path(series_folder(*path_components))
     episode_name = f"{filename}.{extension_output}"
 
     # Generate mpd and license URLs

--- a/VibraVid/services/mostraguarda/downloader.py
+++ b/VibraVid/services/mostraguarda/downloader.py
@@ -8,7 +8,7 @@ from rich.console import Console
 from VibraVid.utils import config_manager, start_message
 from VibraVid.provider.tmdb import tmdb
 from VibraVid.services._base.tv_display_manager import map_movie_path
-from VibraVid.services._base import site_constants, Entries
+from VibraVid.services._base import site_constants, Entries, movie_folder, series_folder
 from VibraVid.services._base.tv_display_manager import map_episode_path
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 
@@ -47,7 +47,7 @@ def download_film(select_title: Entries) -> str:
 
     # Define output path
     path_components, filename = map_movie_path(select_title.name, select_title.year)
-    movie_path = os.path.join(site_constants.MOVIE_FOLDER, *path_components) if path_components else site_constants.MOVIE_FOLDER
+    movie_path = movie_folder(*path_components)
     movie_name = f"{filename}.{extension_output}"
 
     return HLS_Downloader(
@@ -65,7 +65,7 @@ def download_episode(obj_episode, index_season_selected, index_episode_selected,
 
     # Define output path
     path_components, filename = map_episode_path(series_display, getattr(scrape_serie, 'year', None), index_season_selected, index_episode_selected, obj_episode.name)
-    episode_path = os.path.join(site_constants.SERIES_FOLDER, *path_components)
+    episode_path = series_folder(*path_components)
     episode_name = f"{filename}.{extension_output}"
     master_playlist = video_source.get_playlist()
 

--- a/VibraVid/services/nove/downloader.py
+++ b/VibraVid/services/nove/downloader.py
@@ -6,7 +6,7 @@ from rich.console import Console
 from rich.prompt import Prompt
 
 from VibraVid.utils import config_manager, start_message
-from VibraVid.services._base import site_constants, Entries
+from VibraVid.services._base import site_constants, Entries, series_folder
 from VibraVid.services._base.tv_display_manager import map_episode_path
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 
@@ -30,7 +30,7 @@ def download_episode(obj_episode, index_season_selected, index_episode_selected,
 
     # Define filename and path for the downloaded video
     path_components, filename = map_episode_path(scrape_serie.series_name, getattr(scrape_serie, 'year', None), index_season_selected, index_episode_selected, obj_episode.name)
-    episode_path = os.path.join(site_constants.SERIES_FOLDER, *path_components)
+    episode_path = series_folder(*path_components)
     episode_name = f"{filename}.{extension_output}"
 
     # Get m3u8 playlist

--- a/VibraVid/services/raiplay/downloader.py
+++ b/VibraVid/services/raiplay/downloader.py
@@ -10,7 +10,7 @@ from rich.prompt import Prompt
 
 from VibraVid.utils import config_manager, start_message
 from VibraVid.utils.http_client import create_client, get_headers, get_userAgent
-from VibraVid.services._base import site_constants, Entries
+from VibraVid.services._base import site_constants, Entries, movie_folder, series_folder
 from VibraVid.services._base.tv_display_manager import map_movie_path, map_episode_path
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 
@@ -63,7 +63,7 @@ def download_film(select_title: Entries) -> Tuple[str, bool]:
 
     # Define the filename and path for the downloaded film
     path_components, filename = map_movie_path(select_title.name, select_title.year)
-    movie_path = os.path.join(site_constants.MOVIE_FOLDER, *path_components) if path_components else site_constants.MOVIE_FOLDER
+    movie_path = movie_folder(*path_components)
     movie_name = f"{filename}.{extension_output}"
 
     # HLS
@@ -84,7 +84,7 @@ def download_episode(obj_episode, index_season_selected, index_episode_selected,
 
     # Define filename and path
     path_components, filename = map_episode_path(scrape_serie.series_name, getattr(scrape_serie, 'year', None), index_season_selected, index_episode_selected, obj_episode.name)
-    episode_path = os.path.join(site_constants.SERIES_FOLDER, *path_components)
+    episode_path = series_folder(*path_components)
     episode_name = f"{filename}.{extension_output}"
 
     # Get streaming URL

--- a/VibraVid/services/realtime/downloader.py
+++ b/VibraVid/services/realtime/downloader.py
@@ -6,7 +6,7 @@ from rich.console import Console
 from rich.prompt import Prompt
 
 from VibraVid.utils import config_manager, start_message
-from VibraVid.services._base import site_constants, Entries
+from VibraVid.services._base import site_constants, Entries, series_folder
 from VibraVid.services._base.tv_display_manager import map_episode_path
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 
@@ -30,7 +30,7 @@ def download_episode(obj_episode, index_season_selected, index_episode_selected,
 
     # Define filename and path for the downloaded video
     path_components, filename = map_episode_path(scrape_serie.series_name, getattr(scrape_serie, 'year', None), index_season_selected, index_episode_selected, obj_episode.name)
-    episode_path = os.path.join(site_constants.SERIES_FOLDER, *path_components)
+    episode_path = series_folder(*path_components)
     episode_name = f"{filename}.{extension_output}"
 
     # Get hls url

--- a/VibraVid/services/streamingcommunity/downloader.py
+++ b/VibraVid/services/streamingcommunity/downloader.py
@@ -6,7 +6,7 @@ from rich.console import Console
 from rich.prompt import Prompt
 
 from VibraVid.utils import config_manager, start_message
-from VibraVid.services._base import site_constants, Entries
+from VibraVid.services._base import site_constants, Entries, movie_folder, series_folder
 from VibraVid.services._base.tv_display_manager import map_movie_path, map_episode_path
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 from VibraVid.provider.tmdb import tmdb_client
@@ -64,7 +64,7 @@ def download_film(select_title: Entries) -> str:
 
     # Define the filename and path for the downloaded film
     path_components, filename = map_movie_path(select_title.name, select_title.year)
-    movie_path = os.path.join(site_constants.MOVIE_FOLDER, *path_components) if path_components else site_constants.MOVIE_FOLDER
+    movie_path = movie_folder(*path_components)
     movie_name = f"{filename}.{extension_output}"
 
     return HLS_Downloader(m3u8_url=master_playlist, output_path=os.path.join(movie_path, movie_name)).start()
@@ -80,7 +80,7 @@ def download_episode(obj_episode, index_season_selected, index_episode_selected,
 
     # Define filename and path for the downloaded video
     path_components, filename = map_episode_path(series_display, getattr(scrape_serie, 'year', None), index_season_selected, index_episode_selected, obj_episode.name)
-    episode_path = os.path.join(site_constants.SERIES_FOLDER, *path_components)
+    episode_path = series_folder(*path_components)
     episode_name = f"{filename}.{extension_output}"
 
     if tmdb_client.api_key is not None:

--- a/VibraVid/services/tubitv/downloader.py
+++ b/VibraVid/services/tubitv/downloader.py
@@ -8,7 +8,7 @@ from rich.console import Console
 from rich.prompt import Prompt
 
 from VibraVid.utils import config_manager, start_message
-from VibraVid.services._base import site_constants, Entries
+from VibraVid.services._base import site_constants, Entries, movie_folder, series_folder
 from VibraVid.services._base.tv_display_manager import map_movie_path, map_episode_path
 from VibraVid.services._base.tv_download_manager import process_season_selection, process_episode_download
 
@@ -61,7 +61,7 @@ def download_film(select_title: Entries) -> Tuple[str, bool]:
 
     # Define the filename and path for the downloaded film
     path_components, filename = map_movie_path(select_title.name, select_title.year)
-    movie_path = os.path.join(site_constants.MOVIE_FOLDER, *path_components) if path_components else site_constants.MOVIE_FOLDER
+    movie_path = movie_folder(*path_components)
     movie_name = f"{filename}.{extension_output}"
 
     return DASH_Downloader(mpd_url=master_playlist, mpd_headers=custom_headers, output_path=os.path.join(movie_path, movie_name), license_url=license_url).start()
@@ -76,7 +76,7 @@ def download_episode(obj_episode, index_season_selected, index_episode_selected,
 
     # Define filename and path for the downloaded video
     path_components, filename = map_episode_path(scrape_serie.series_name, getattr(scrape_serie, 'year', None), index_season_selected, index_episode_selected, obj_episode.name)
-    episode_path = os.path.join(site_constants.SERIES_FOLDER, *path_components)
+    episode_path = series_folder(*path_components)
     episode_name = f"{filename}.{extension_output}"
 
     # Get master playlist URL


### PR DESCRIPTION
**Disclaimer:** _AI has been used to understand the code instead to have manually check every single line of the repository to understand how it works. All the code has been reviewed and fixed manually._

## Summary

This PR fixes several ARR integration issues found while testing Sonarr/Radarr downloads:

- respect the configured `provider_fallback` order when no `provider-*` tag is set
- preserve explicit `provider-*` tags when present
- download ARR items into the ARR-provided output path
- support path mapping in both directions, so VibraVid can write to its own container path while Sonarr/Radarr still scan their own path
- fix AnimeUnity season handling for multi-season anime
- avoid storing string season/episode values in `context_tracker`

## Why

Previously, missing ARR items without a provider tag could default to `streamingcommunity` instead of following the configured fallback order.

Also, Sonarr/Radarr paths were only translated when asking ARR to scan/import files. When VibraVid had a different container mount path, downloads could fail with permission errors like:

```text
PermissionError: [Errno 13] Permission denied: '/data'
```

because VibraVid tried to write to the ARR container path instead of its own mapped path.

AnimeUnity multi-season downloads also needed the season context to avoid writing/identifying episodes as season 1.

## Changes
- Use empty provider when no provider-* tag exists, allowing configured fallback order to drive provider selection.
- Extract provider tags from Sonarr/Radarr webhook payloads.
- Pass ARR output paths through the download context.
- Add reverse path mapping via _translate_path(..., reverse=True).
- Keep scan/import paths translated in the existing VibraVid -> ARR direction.
- Pass AnimeUnity season only when available.
- Store numeric season/episode values in context_tracker.

## Validation
- Verified touched Python modules with compileall.
- Tested with Docker/ARR setup using different VibraVid and Sonarr container paths.