### PR TITLE
[Arr] Better handling for *arr queue items and title matching

### DIFF
--- a/GUI/searchapp/arr/arr_service.py
+++ b/GUI/searchapp/arr/arr_service.py
@@ -262,6 +262,170 @@ def _enqueue_if_new(item: dict, sync_source: str, season_num: Optional[int] = No
         return True
 
 
+def _mark_downloading(item: dict, season_num=None, ep_num=None) -> None:
+    """Mark an active queue row as started so unmonitor cleanup leaves it alone."""
+    from searchapp.models import ArrMediaRequest, ArrProcessingQueue
+
+    key = _dedup_key(item, season_num, ep_num)
+    try:
+        queue_entry = ArrProcessingQueue.objects.filter(dedup_key=key, completed_at__isnull=True).first()
+        if queue_entry:
+            update_fields = []
+            if queue_entry.started_at is None:
+                queue_entry.started_at = timezone.now()
+                update_fields.append("started_at")
+            if update_fields:
+                queue_entry.save(update_fields=update_fields)
+            queue_entry.media_request.status = ArrMediaRequest.Status.DOWNLOADING
+            queue_entry.media_request.save(update_fields=["status"])
+    except Exception as exc:
+        logger.error(f"Failed to mark downloading {key}: {exc}")
+
+
+def _skip_pending_queue_entry(queue_entry, reason: str) -> bool:
+    """Close a not-yet-started queue row as skipped."""
+    from searchapp.models import ArrMediaRequest
+
+    if queue_entry.started_at or queue_entry.completed_at:
+        return False
+
+    queue_entry.completed_at = timezone.now()
+    queue_entry.success = False
+    queue_entry.save(update_fields=["completed_at", "success"])
+    queue_entry.media_request.status = ArrMediaRequest.Status.SKIPPED
+    queue_entry.media_request.save(update_fields=["status"])
+    logger.info(f"Skipped pending ARR queue '{queue_entry.dedup_key}': {reason}")
+    return True
+
+
+def _skip_pending_queue(item: dict, reason: str, season_num=None, ep_num=None) -> bool:
+    """Skip a matching pending queue row if it has not started yet."""
+    from searchapp.models import ArrProcessingQueue
+
+    key = _dedup_key(item, season_num, ep_num)
+    queue_entry = ArrProcessingQueue.objects.filter(
+        dedup_key=key,
+        completed_at__isnull=True,
+        started_at__isnull=True,
+    ).select_related("media_request").first()
+    if not queue_entry:
+        return False
+    return _skip_pending_queue_entry(queue_entry, reason)
+
+
+def _is_radarr_movie_monitored(radarr, item: dict) -> bool:
+    """Return False when Radarr currently marks the movie as unmonitored."""
+    if item.get("monitored") is False:
+        return False
+    if not radarr or not item.get("id"):
+        return True
+    try:
+        movie = radarr.get_movie_by_id(item["id"])
+        return movie.get("monitored", True) is not False
+    except Exception as exc:
+        logger.warning(f"Could not verify Radarr monitored state for movie {item.get('id')}: {exc}")
+        return True
+
+
+def _is_sonarr_episode_monitored(sonarr, item: dict, episode: dict) -> bool:
+    """Return False when Sonarr currently marks the series/episode as unmonitored."""
+    if item.get("monitored") is False or episode.get("monitored") is False:
+        return False
+    episode_id = episode.get("id")
+    if not sonarr or not episode_id:
+        return True
+    try:
+        current = sonarr.get_episode(episode_id)
+        return current.get("monitored", True) is not False
+    except Exception as exc:
+        logger.warning(f"Could not verify Sonarr monitored state for episode {episode_id}: {exc}")
+        return True
+
+
+def _skip_unmonitored_movie(radarr, item: dict, context: str) -> bool:
+    """Skip a pending movie queue row if Radarr currently marks it unmonitored."""
+    if _is_radarr_movie_monitored(radarr, item):
+        return False
+
+    _skip_pending_queue(item, "Radarr movie is unmonitored")
+    logger.info(f"{context} Movie '{item.get('title')}' is unmonitored in Radarr, skipping")
+    return True
+
+
+def _skip_unmonitored_episode(sonarr, item: dict, season: dict, episode: dict, context: str) -> bool:
+    """Skip a pending episode queue row if Sonarr currently marks it unmonitored."""
+    if _is_sonarr_episode_monitored(sonarr, item, episode):
+        return False
+
+    _skip_pending_queue(
+        item,
+        "Sonarr episode is unmonitored",
+        season["number"],
+        episode["episodeNumber"],
+    )
+    logger.info(
+        f"{context} Skipping '{item.get('title')}' S{season['number']}E{episode['episodeNumber']} "
+        "because Sonarr marks it unmonitored"
+    )
+    return True
+
+
+def _reconcile_unmonitored_pending(sonarr=None, radarr=None) -> int:
+    """Skip pending queue rows whose ARR item is now unmonitored.
+
+    Rows already marked as started are intentionally left untouched so an
+    in-flight download can finish.
+    """
+    from searchapp.models import ArrMediaRequest, ArrProcessingQueue
+
+    candidates = ArrProcessingQueue.objects.filter(
+        completed_at__isnull=True,
+        started_at__isnull=True,
+        media_request__status=ArrMediaRequest.Status.PENDING,
+    ).select_related("media_request")
+
+    skipped = 0
+    series_cache = {}
+    for queue_entry in candidates:
+        req = queue_entry.media_request
+        try:
+            if req.arr_source == "radarr" and radarr:
+                movie = radarr.get_movie_by_id(req.arr_id)
+                if movie.get("monitored", True) is False:
+                    skipped += int(_skip_pending_queue_entry(queue_entry, "Radarr movie is unmonitored"))
+
+            elif req.arr_source == "sonarr" and sonarr:
+                series = series_cache.get(req.arr_id)
+                if series is None:
+                    series = sonarr.get_series_by_id(req.arr_id)
+                    series_cache[req.arr_id] = series
+                if series.get("monitored", True) is False:
+                    skipped += int(_skip_pending_queue_entry(queue_entry, "Sonarr series is unmonitored"))
+                    continue
+
+                episode = None
+                if req.episode_id:
+                    episode = sonarr.get_episode(req.episode_id)
+                elif req.season_number is not None and req.episode_number is not None:
+                    episodes = sonarr.get_episodes_for_series(req.arr_id)
+                    episode = next(
+                        (
+                            ep for ep in episodes
+                            if ep.get("seasonNumber") == req.season_number
+                            and ep.get("episodeNumber") == req.episode_number
+                        ),
+                        None,
+                    )
+                if episode and episode.get("monitored", True) is False:
+                    skipped += int(_skip_pending_queue_entry(queue_entry, "Sonarr episode is unmonitored"))
+        except Exception as exc:
+            logger.warning(f"Could not reconcile monitored state for '{queue_entry.dedup_key}': {exc}")
+
+    if skipped:
+        logger.info(f"Skipped {skipped} pending ARR queue item(s) now marked unmonitored")
+    return skipped
+
+
 def _should_skip_seerr_event(event_data: dict, cfg: dict) -> bool:
     """Native webhook priority: Sonarr/Radarr events win over Seerr."""
     from searchapp.models import ArrWebhookEvent
@@ -345,6 +509,7 @@ def trigger_polling_sync(full_resync: bool = False) -> int:
     from .processor_service import ArrProcessorService
     from .downloader_service import ArrDownloaderService
     _reconcile_recent_import_failures()
+    _reconcile_unmonitored_pending(sonarr=sonarr, radarr=radarr)
 
     processor = ArrProcessorService(
         sonarr=sonarr,
@@ -366,9 +531,12 @@ def trigger_polling_sync(full_resync: bool = False) -> int:
         content_type = item.get("content_type")
 
         if content_type == "movie":
+            if _skip_unmonitored_movie(radarr, item, "[polling]"):
+                continue
             if _enqueue_if_new(item, "polling"):
                 enqueued += 1
                 try:
+                    _mark_downloading(item)
                     if downloader._process_movie(item):
                         _mark_completed(item)
                     else:
@@ -381,6 +549,8 @@ def trigger_polling_sync(full_resync: bool = False) -> int:
             for season in item.get("seasons", []):
                 for episode in season.get("episodes", []):
                     ep_item = {**item, "seasons": [{"number": season["number"], "episodes": [episode]}]}
+                    if _skip_unmonitored_episode(sonarr, item, season, episode, "[polling]"):
+                        continue
                     if _enqueue_if_new(
                         item, "polling",
                         season_num=season["number"],
@@ -389,6 +559,7 @@ def trigger_polling_sync(full_resync: bool = False) -> int:
                     ):
                         enqueued += 1
                         try:
+                            _mark_downloading(item, season["number"], episode["episodeNumber"])
                             if downloader._process_serie(ep_item):
                                 _mark_completed(item, season["number"], episode["episodeNumber"])
                             else:
@@ -470,6 +641,7 @@ def trigger_webhook_sync(event_data: dict) -> int:
     if not sonarr and not radarr:
         logger.warning("[trigger_webhook_sync] No Sonarr/Radarr clients configured, skipping")
         return 0
+    _reconcile_unmonitored_pending(sonarr=sonarr, radarr=radarr)
 
     import searchapp.views as arr_views_mod
     arr_views_mod.set_max_download_slots(cfg.get("max_concurrent_downloads", 1))
@@ -551,8 +723,12 @@ def trigger_webhook_sync(event_data: dict) -> int:
             "path": matched.get("path", ""),
             "tags": matched.get("tags", []),
             "tmdbId": matched.get("tmdbId"),
+            "monitored": matched.get("monitored", True),
             "provider": provider,
         }
+
+        if _skip_unmonitored_movie(radarr, item, "[trigger_webhook_sync]"):
+            return -1
 
         if not _enqueue_if_new(item, "webhook"):
             logger.info(f"[trigger_webhook_sync] Movie '{matched['title']}' already enqueued, skipping")
@@ -560,6 +736,7 @@ def trigger_webhook_sync(event_data: dict) -> int:
 
         logger.info(f"[trigger_webhook_sync] Starting download for movie '{matched['title']}'")
         downloader = ArrDownloaderService(sonarr, radarr)
+        _mark_downloading(item)
         if downloader._process_movie(item):
             _mark_completed(item)
             logger.info(f"[trigger_webhook_sync] Movie '{matched['title']}' processed successfully")
@@ -653,8 +830,13 @@ def trigger_webhook_sync(event_data: dict) -> int:
             "path": matched.get("path", ""),
             "tags": matched.get("tags", []),
             "tmdbId": matched.get("tmdbId"),
+            "monitored": matched.get("monitored", True),
             "provider": _extract_provider_from_tags(sonarr, matched.get("tags", [])),
         }
+
+        if serie_item.get("monitored") is False:
+            logger.info(f"[trigger_webhook_sync] Series '{matched['title']}' is unmonitored in Sonarr, skipping")
+            return -1
 
         if not processor._check_tags_validity(serie_item["title"], serie_item["tags"]):
             logger.info(f"[trigger_webhook_sync] Series '{matched['title']}' filtered out by tag rules, skipping")
@@ -690,6 +872,7 @@ def trigger_webhook_sync(event_data: dict) -> int:
                 "title": ep.get("title", ""),
                 "seasonNumber": s_num,
                 "episodeNumber": ep["episodeNumber"],
+                "monitored": ep.get("monitored", True),
             })
 
         serie_item["seasons"] = list(seasons_dict.values())
@@ -699,6 +882,8 @@ def trigger_webhook_sync(event_data: dict) -> int:
         for season in serie_item.get("seasons", []):
             for episode in season.get("episodes", []):
                 ep_item = {**serie_item, "seasons": [{"number": season["number"], "episodes": [episode]}]}
+                if _skip_unmonitored_episode(sonarr, serie_item, season, episode, "[trigger_webhook_sync]"):
+                    continue
                 if _enqueue_if_new(
                     serie_item, "webhook",
                     season_num=season["number"],
@@ -708,6 +893,7 @@ def trigger_webhook_sync(event_data: dict) -> int:
                     local_enqueued += 1
                     try:
                         logger.info(f"[trigger_webhook_sync] Processing S{season['number']}E{episode['episodeNumber']}")
+                        _mark_downloading(serie_item, season["number"], episode["episodeNumber"])
                         if downloader._process_serie(ep_item):
                             _mark_completed(serie_item, season["number"], episode["episodeNumber"])
                         else:
@@ -749,6 +935,7 @@ def trigger_sonarr_webhook_sync(event_data: dict) -> int:
     if not sonarr:
         logger.warning("[Sonarr WH] Sonarr not configured, ignoring webhook")
         return 0
+    _reconcile_unmonitored_pending(sonarr=sonarr, radarr=None)
 
     import searchapp.views as arr_views_mod
     arr_views_mod.set_max_download_slots(cfg.get("max_concurrent_downloads", 1))
@@ -782,8 +969,13 @@ def trigger_sonarr_webhook_sync(event_data: dict) -> int:
         "path": series.get("path", ""),
         "tags": series.get("tags", []),
         "tmdbId": series.get("tmdbId"),
+        "monitored": series.get("monitored", True),
         "provider": _extract_provider_from_tags(sonarr, series.get("tags", [])),
     }
+
+    if serie.get("monitored") is False:
+        logger.info(f"[Sonarr WH] Series '{serie['title']}' is unmonitored, skipping")
+        return -1
 
     # Apply tag filtering
     from .processor_service import ArrProcessorService
@@ -836,6 +1028,7 @@ def trigger_sonarr_webhook_sync(event_data: dict) -> int:
                 "title": ep.get("title", ""),
                 "seasonNumber": s_num,
                 "episodeNumber": ep["episodeNumber"],
+                "monitored": ep.get("monitored", True),
             })
 
         serie["seasons"] = list(seasons_dict.values())
@@ -844,6 +1037,8 @@ def trigger_sonarr_webhook_sync(event_data: dict) -> int:
         for season in serie.get("seasons", []):
             for episode in season.get("episodes", []):
                 ep_item = {**serie, "seasons": [{"number": season["number"], "episodes": [episode]}]}
+                if _skip_unmonitored_episode(sonarr, serie, season, episode, "[Sonarr WH]"):
+                    continue
                 if _enqueue_if_new(
                     serie, "webhook",
                     season_num=season["number"],
@@ -853,6 +1048,7 @@ def trigger_sonarr_webhook_sync(event_data: dict) -> int:
                     enqueued += 1
                     try:
                         logger.info(f"[Sonarr WH] Processing S{season['number']}E{episode['episodeNumber']}")
+                        _mark_downloading(serie, season["number"], episode["episodeNumber"])
                         if downloader._process_serie(ep_item):
                             _mark_completed(serie, season["number"], episode["episodeNumber"])
                         else:
@@ -887,6 +1083,7 @@ def trigger_sonarr_webhook_sync(event_data: dict) -> int:
             "title": ep.get("title", ""),
             "seasonNumber": s_num,
             "episodeNumber": ep.get("episodeNumber"),
+            "monitored": ep.get("monitored", True),
         })
 
     serie["seasons"] = list(seasons_dict.values())
@@ -898,6 +1095,8 @@ def trigger_sonarr_webhook_sync(event_data: dict) -> int:
     for season in serie.get("seasons", []):
         for episode in season.get("episodes", []):
             ep_item = {**serie, "seasons": [{"number": season["number"], "episodes": [episode]}]}
+            if _skip_unmonitored_episode(sonarr, serie, season, episode, "[Sonarr WH]"):
+                continue
             if _enqueue_if_new(
                 serie, "webhook",
                 season_num=season["number"],
@@ -906,6 +1105,7 @@ def trigger_sonarr_webhook_sync(event_data: dict) -> int:
             ):
                 enqueued += 1
                 try:
+                    _mark_downloading(serie, season["number"], episode["episodeNumber"])
                     if downloader._process_serie(ep_item):
                         _mark_completed(serie, season["number"], episode["episodeNumber"])
                     else:
@@ -937,6 +1137,7 @@ def trigger_radarr_webhook_sync(event_data: dict) -> int:
     if not radarr:
         logger.warning("[Radarr WH] Radarr not configured, ignoring webhook")
         return 0
+    _reconcile_unmonitored_pending(sonarr=None, radarr=radarr)
 
     import searchapp.views as arr_views_mod
     arr_views_mod.set_max_download_slots(cfg.get("max_concurrent_downloads", 1))
@@ -970,8 +1171,12 @@ def trigger_radarr_webhook_sync(event_data: dict) -> int:
         "path": movie.get("path", ""),
         "tags": movie.get("tags", []),
         "tmdbId": movie.get("tmdbId"),
+        "monitored": movie.get("monitored", True),
         "provider": _extract_provider_from_tags(radarr, movie.get("tags", [])),
     }
+
+    if _skip_unmonitored_movie(radarr, movie_item, "[Radarr WH]"):
+        return -1
 
     # Apply tag filtering
     from .processor_service import ArrProcessorService
@@ -993,6 +1198,7 @@ def trigger_radarr_webhook_sync(event_data: dict) -> int:
     from .downloader_service import ArrDownloaderService
     downloader = ArrDownloaderService(None, radarr)
     try:
+        _mark_downloading(movie_item)
         if downloader._process_movie(movie_item):
             _mark_completed(movie_item)
             logger.info(f"[Radarr WH] Movie '{movie_item['title']}' processed successfully")

--- a/GUI/searchapp/arr/arr_service.py
+++ b/GUI/searchapp/arr/arr_service.py
@@ -331,6 +331,13 @@ def _is_sonarr_episode_monitored(sonarr, item: dict, episode: dict) -> bool:
     """Return False when Sonarr currently marks the series/episode as unmonitored."""
     if item.get("monitored") is False or episode.get("monitored") is False:
         return False
+    if sonarr and item.get("id"):
+        try:
+            series = sonarr.get_series_by_id(item["id"])
+            if series.get("monitored", True) is False:
+                return False
+        except Exception as exc:
+            logger.warning(f"Could not verify Sonarr monitored state for series {item.get('id')}: {exc}")
     episode_id = episode.get("id")
     if not sonarr or not episode_id:
         return True

--- a/GUI/searchapp/arr/downloader_service.py
+++ b/GUI/searchapp/arr/downloader_service.py
@@ -76,6 +76,11 @@ class ArrDownloaderService:
                     logger.info(f"S{season_num}E{ep_num} of '{title}' already in Sonarr queue, skipping")
                     continue
 
+                if not self._is_sonarr_episode_still_monitored(series_id, ep_id):
+                    logger.info(f"S{season_num}E{ep_num} of '{title}' is now unmonitored in Sonarr, skipping")
+                    self.last_error = "sonarr_unmonitored"
+                    continue
+
                 display_title = f"{titles[0]} - S{season_num} E{ep_num}"
                 logger.info(f"⏳ Downloading '{display_title}' via {provider or 'configured fallback order'}")
 
@@ -199,6 +204,11 @@ class ArrDownloaderService:
             logger.info(f"'{title}' already in Radarr queue, skipping")
             return False
 
+        if not self._is_radarr_movie_still_monitored(movie_id):
+            logger.info(f"'{title}' is now unmonitored in Radarr, skipping")
+            self.last_error = "radarr_unmonitored"
+            return False
+
         titles = self._resolve_radarr_title(title, movie_id, tmdb_id) or [title]
 
         year = movie.get("year")
@@ -302,6 +312,34 @@ class ArrDownloaderService:
             return False
 
     # ── helpers ──────────────────────────────────────────
+
+    def _is_radarr_movie_still_monitored(self, movie_id: Optional[int]) -> bool:
+        """Read Radarr live state before starting a movie download."""
+        if not self.radarr or not movie_id:
+            return True
+        try:
+            movie = self.radarr.get_movie_by_id(movie_id)
+            return movie.get("monitored", True) is not False
+        except Exception as exc:
+            logger.warning(f"Could not verify Radarr monitored state before download: {exc}")
+            return True
+
+    def _is_sonarr_episode_still_monitored(self, series_id: Optional[int], episode_id: Optional[int]) -> bool:
+        """Read Sonarr live state before starting an episode download."""
+        if not self.sonarr:
+            return True
+        try:
+            if series_id:
+                series = self.sonarr.get_series_by_id(series_id)
+                if series.get("monitored", True) is False:
+                    return False
+            if episode_id:
+                episode = self.sonarr.get_episode(episode_id)
+                if episode.get("monitored", True) is False:
+                    return False
+        except Exception as exc:
+            logger.warning(f"Could not verify Sonarr monitored state before download: {exc}")
+        return True
 
     @staticmethod
     def _translate_path(path: str, reverse: bool = False) -> str:

--- a/GUI/searchapp/arr/downloader_service.py
+++ b/GUI/searchapp/arr/downloader_service.py
@@ -13,7 +13,7 @@ import json
 import logging
 import pathlib
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from .clients.sonarr_client import SonarrClient
 from .clients.radarr_client import RadarrClient
@@ -53,11 +53,9 @@ class ArrDownloaderService:
         provider = (serie.get("provider") or "").strip()
         any_success = False
 
-        # Resolve original title from Sonarr or TMDB
         tmdb_id = serie.get("tmdbId")
-        original_title = self._resolve_sonarr_title(title, series_id, tmdb_id)
-        search_title = original_title or title
-        logger.info(f"[_process_serie] Title='{title}', Original='{original_title}', Search='{search_title}', TMDB ID='{tmdb_id}'")
+        titles = self._resolve_sonarr_title(title, series_id, tmdb_id) or [title]
+        logger.info(f"[_process_serie] Title='{title}', Title candidates={titles}, TMDB ID='{tmdb_id}'")
 
         year = serie.get("year")
         year_range = self._build_year_range(year)
@@ -78,20 +76,19 @@ class ArrDownloaderService:
                     logger.info(f"S{season_num}E{ep_num} of '{title}' already in Sonarr queue, skipping")
                     continue
 
-                display_title = f"{search_title} - S{season_num} E{ep_num}"
+                display_title = f"{titles[0]} - S{season_num} E{ep_num}"
                 logger.info(f"⏳ Downloading '{display_title}' via {provider or 'configured fallback order'}")
 
-                item_payload, provider = self._search_with_fallback(
-                    search_title, provider,
+                item_payload, provider, matched_title = self._search_with_fallback_titles(
+                    titles, provider,
                     year_range=year_range,
-                    expected_title=search_title,
                     expected_year=year,
                     tmdb_id=serie.get("tmdbId"),
                     media_type="tv",
                     season_number=season_num,
                 )
                 if not item_payload:
-                    logger.error(f"✖️ Could not find '{search_title}' on any provider")
+                    logger.error(f"✖️ Could not find '{title}' using candidates: {titles}")
                     self.last_error = "search_no_results"
                     continue
 
@@ -150,7 +147,7 @@ class ArrDownloaderService:
                             logger.warning(f"Failed to verify Sonarr episode import: {exc}")
                         time.sleep(5)
                     if not imported:
-                        result_name = item_payload.get("name", search_title)
+                        result_name = item_payload.get("name", matched_title)
                         result_year = item_payload.get("year", year)
                         fallback_folder = self._get_vibrativo_serie_output(series_root, result_name, season_num, result_year)
                         if fallback_folder and fallback_folder != target_folder:
@@ -202,25 +199,25 @@ class ArrDownloaderService:
             logger.info(f"'{title}' already in Radarr queue, skipping")
             return False
 
-        # Resolve original title from Radarr (passes tmdb_id for non-ASCII fallback)
-        original_title = self._resolve_radarr_title(movie_id, tmdb_id)
-        search_title = original_title or title
+        titles = self._resolve_radarr_title(title, movie_id, tmdb_id) or [title]
 
         year = movie.get("year")
         year_range = self._build_year_range(year)
 
-        logger.info(f"⏳ Downloading movie '{search_title}' ({year}) via {provider or 'configured fallback order'}")
+        logger.info(
+            f"⏳ Downloading movie '{titles[0]}' ({year}) "
+            f"via {provider or 'configured fallback order'}; candidates={titles}"
+        )
 
-        item_payload, provider = self._search_with_fallback(
-            search_title, provider,
+        item_payload, provider, matched_title = self._search_with_fallback_titles(
+            titles, provider,
             year_range=year_range,
-            expected_title=search_title,
             expected_year=year,
             tmdb_id=tmdb_id,
             media_type="movie",
         )
         if not item_payload:
-            logger.error(f"Could not find movie '{search_title}' on any provider")
+            logger.error(f"Could not find movie '{title}' using candidates: {titles}")
             self.last_error = "search_no_results"
             return False
 
@@ -247,7 +244,7 @@ class ArrDownloaderService:
             future.result(timeout=7200)  # wait for download to actually finish
             time.sleep(2)
 
-            result_name = item_payload.get("name", search_title)
+            result_name = item_payload.get("name", matched_title)
             result_year = item_payload.get("year", year)
             fallback_folder = self._get_vibrativo_movie_output(target_folder, result_name, result_year)
 
@@ -347,8 +344,8 @@ class ArrDownloaderService:
         )
 
     @staticmethod
-    def _titles_are_compatible(search_title: str, result_name: str) -> bool:
-        """Check that result_name shares enough significant words with search_title.
+    def _titles_are_compatible(title: str, result_name: str) -> bool:
+        """Check that result_name shares enough significant words with title.
 
         Guards against accepting completely unrelated titles that happen to match
         the year range (e.g. 'My Teacher' when searching 'My Hero Academia').
@@ -362,7 +359,7 @@ class ArrDownloaderService:
             s = ArrDownloaderService._strip_accents(s)
             return {w.lower() for w in re.split(r'\W+', s) if len(w) > 3}
 
-        sw = sig_words(search_title)
+        sw = sig_words(title)
         if not sw:
             # Non-ASCII title (e.g. Japanese/Korean) — can't verify by word match,
             # reject to force TMDB ID check or fallback providers
@@ -429,21 +426,7 @@ class ArrDownloaderService:
 
         Returns (payload, used_provider). payload is None if nothing found anywhere.
         """
-        conf_path = pathlib.Path(__file__).parent.parent.parent.parent / "Conf" / "config.json"
-        try:
-            with open(conf_path, encoding="utf-8") as _f:
-                fallback_list: list = json.load(_f).get("ARR", {}).get("provider_fallback", [])
-        except Exception as _exc:
-            logger.warning(f"[fallback] Could not read provider_fallback from config: {_exc}")
-            fallback_list = []
-
-        providers = []
-        if primary_provider:
-            providers.append(primary_provider)
-        providers.extend(provider for provider in fallback_list if provider and provider not in providers)
-        if not providers:
-            providers = ["streamingcommunity"]
-
+        providers = self._provider_order(primary_provider)
         logger.info(f"[fallback] Search '{title}' — provider order: {providers}")
         for index, provider in enumerate(providers):
             label = "primary" if index == 0 else "fallback"
@@ -461,6 +444,59 @@ class ArrDownloaderService:
         logger.error(f"[fallback] '{title}' not found on any provider (tried: {providers})")
         return None, primary_provider or (providers[0] if providers else "")
 
+    def _provider_order(self, primary_provider: str) -> List[str]:
+        """Return primary provider followed by configured ARR provider fallbacks."""
+        conf_path = pathlib.Path(__file__).parent.parent.parent.parent / "Conf" / "config.json"
+        try:
+            with open(conf_path, encoding="utf-8") as _f:
+                fallback_list: list = json.load(_f).get("ARR", {}).get("provider_fallback", [])
+        except Exception as _exc:
+            logger.warning(f"[fallback] Could not read provider_fallback from config: {_exc}")
+            fallback_list = []
+
+        providers = []
+        if primary_provider:
+            providers.append(primary_provider)
+        providers.extend(provider for provider in fallback_list if provider and provider not in providers)
+        if not providers:
+            providers = ["streamingcommunity"]
+        return providers
+
+    def _search_with_fallback_titles(
+        self,
+        titles: List[str],
+        primary_provider: str,
+        **kwargs,
+    ) -> Tuple[Optional[Dict[str, Any]], str, str]:
+        """Try title candidates inside each provider, preserving provider order.
+
+        Returns the accepted payload, provider, and title that produced the
+        match. If every candidate fails, payload is None and the returned title
+        is the first candidate for logging/path fallback purposes.
+        """
+        candidates = self._unique_titles(titles)
+        providers = self._provider_order(primary_provider)
+        logger.info(f"[title_fallback] Provider order: {providers}; title candidates: {candidates}")
+
+        for provider_index, provider in enumerate(providers):
+            label = "primary" if provider_index == 0 else "fallback"
+            for title in candidates:
+                logger.info(f"[title_fallback] Trying {label} '{provider}' with title '{title}'")
+                payload = self._search_and_build_payload(
+                    title,
+                    provider,
+                    expected_title=title,
+                    **kwargs,
+                )
+                if payload:
+                    logger.info(f"[title_fallback] Accepted title '{title}' on {label} '{provider}'")
+                    return payload, provider, title
+
+                logger.warning(f"[title_fallback] No match for title '{title}' on '{provider}'")
+
+        fallback_provider = primary_provider or (providers[0] if providers else "")
+        return None, fallback_provider, candidates[0] if candidates else ""
+
     def _search_and_build_payload(self, title: str, provider: str,
                                   year_range: Optional[str] = None,
                                   expected_title: Optional[str] = None,
@@ -470,30 +506,13 @@ class ArrDownloaderService:
                                   season_number: Optional[int] = None) -> Optional[Dict[str, Any]]:
         """Search VibraVid's streaming API for a title and return an item_payload dict.
 
-        Uses TMDB API to get alternative titles for verification when tmdb_id is provided.
-        This handles translations (e.g., "Born Again" vs "Rinascita") correctly.
+        Verifies candidate results using TMDB id, media type, title compatibility,
+        and year range. Localized title fallback is handled before this method.
         """
         try:
             from searchapp.api import get_api
 
             api = get_api(provider)
-
-            # Get alternative titles from TMDB if tmdb_id is available
-            tmdb_titles = []
-            if tmdb_id:
-                try:
-                    from VibraVid.provider.tmdb import tmdb_client as tmdb
-
-                    # Get titles in Italian (for streamingcommunity) and English
-                    for lang in ["it", "en"]:
-                        alt_titles = tmdb.get_alternative_titles(tmdb_id, media_type, lang)
-                        tmdb_titles.extend(alt_titles)
-
-                    # Deduplicate
-                    tmdb_titles = list(set(t.strip() for t in tmdb_titles if t.strip()))
-                    logger.info(f"TMDB alternative titles for {tmdb_id}: {tmdb_titles[:5]}")
-                except Exception as tmdb_exc:
-                    logger.debug(f"Failed to get TMDB alternative titles: {tmdb_exc}")
 
             # Strip accents from search query: à→a, è→e, ì→i, ò→o, ù→u …
             search_query = self._strip_accents(title).strip()
@@ -707,99 +726,122 @@ class ArrDownloaderService:
             logger.error(f"Search failed for '{title}' on {provider}: {exc}")
             return None
 
-    def _resolve_sonarr_title(self, title: str, series_id: Optional[int], tmdb_id: Optional[int] = None) -> Optional[str]:
-        """Try to get the original title from Sonarr for better search results.
+    @staticmethod
+    def _unique_titles(titles: List[Optional[str]]) -> List[str]:
+        """Return non-empty title candidates deduplicated by normalized title.
 
-        First tries Sonarr's originalTitle. If not set, falls back to TMDB API
-        to get the Italian title directly from tmdbId.
+        Preserves the first occurrence so caller-provided priority order remains
+        intact while removing case/accent/punctuation-equivalent duplicates.
         """
-        sonarr_original = None
+        unique: List[str] = []
+        seen = set()
+        for raw_title in titles:
+            candidate = str(raw_title or "").strip()
+            if not candidate:
+                continue
+            key = ArrDownloaderService._normalize_title(candidate)
+            if not key or key in seen:
+                continue
+            seen.add(key)
+            unique.append(candidate)
+        return unique
 
-        # Primary: fast lookup by ID
+    def _get_tmdb_title_candidates(self, tmdb_id: Optional[int], media_type: str) -> List[str]:
+        """Return localized and alternative TMDB titles for search fallback.
+
+        Includes Italian and English details plus TMDB alternative titles, then
+        normalizes/deduplicates them while preserving priority order.
+        """
+        if not tmdb_id:
+            return []
+
+        titles: List[str] = []
+        try:
+            from VibraVid.provider.tmdb import tmdb_client as tmdb
+
+            endpoint = "movie" if media_type == "movie" else "tv"
+            detail_key = "title" if media_type == "movie" else "name"
+            for lang in ["it", "en"]:
+                try:
+                    details = tmdb._make_request(f"{endpoint}/{tmdb_id}", {"language": lang})
+                    titles.append(details.get(detail_key, ""))
+                except Exception as details_exc:
+                    logger.debug(f"Failed to get TMDB {lang} title for {media_type}/{tmdb_id}: {details_exc}")
+
+                try:
+                    titles.extend(tmdb.get_alternative_titles(tmdb_id, media_type, lang))
+                except Exception as alt_exc:
+                    logger.debug(f"Failed to get TMDB {lang} alternative titles for {media_type}/{tmdb_id}: {alt_exc}")
+        except Exception as tmdb_exc:
+            logger.debug(f"Failed to collect TMDB title candidates for {media_type}/{tmdb_id}: {tmdb_exc}")
+
+        return self._unique_titles(titles)
+
+    def _resolve_sonarr_title(self, title: str, series_id: Optional[int], tmdb_id: Optional[int] = None) -> List[str]:
+        """Build ordered Sonarr title candidates for VibraVid searches.
+
+        Starts with Sonarr's originalTitle and localized title, then adds TMDB
+        localized/alternative titles, a secondary Sonarr list lookup by
+        title/slug/originalTitle, and finally the title from the ARR item.
+        """
+        titles: List[Optional[str]] = []
+
         if series_id:
             try:
                 series = self.sonarr.get_series_by_id(series_id)
                 sonarr_title = series.get("title", "")
                 sonarr_original = series.get("originalTitle", "")
-                logger.info(f"[_resolve_sonarr_title] Sonarr title='{sonarr_title}', originalTitle='{sonarr_original}'")
-
-                if sonarr_original and sonarr_original.lower() != title.lower():
-                    logger.info(f"Using original title from Sonarr: '{sonarr_original}'")
-                    return sonarr_original
+                logger.info(
+                    f"[_resolve_sonarr_title] Sonarr title='{sonarr_title}', "
+                    f"originalTitle='{sonarr_original}'"
+                )
+                titles.extend([sonarr_original, sonarr_title])
             except Exception as exc:
                 logger.debug(f"Sonarr series lookup by ID {series_id} failed: {exc}")
 
-        # Fallback: get Italian title from TMDB if originalTitle is not set
-        if tmdb_id and (not sonarr_original or sonarr_original.lower() == title.lower()):
+        titles.extend(self._get_tmdb_title_candidates(tmdb_id, "tv"))
+
+        if not self._unique_titles(titles):
+            # Secondary lookup: if direct lookup by ID and TMDB lookup are
+            # unavailable, scan Sonarr's series list and match by title/slug/originalTitle.
             try:
-                from VibraVid.provider.tmdb import tmdb_client as tmdb
-                details = tmdb._make_request(f"tv/{tmdb_id}", {"language": "it"})
-                it_title = details.get("name", "")
+                series_list = self.sonarr.get_series()
+                title_lower = title.lower()
+                for s in series_list:
+                    s_title = s.get("title", "").lower()
+                    s_slug = s.get("titleSlug", "").lower()
+                    s_original = s.get("originalTitle", "").lower()
+                    if title_lower in (s_title, s_slug, s_original):
+                        titles.extend([s.get("originalTitle"), s.get("title")])
+                        break
+            except Exception as exc:
+                logger.debug(f"Sonarr series list fallback failed: {exc}")
 
-                if it_title and it_title.lower() != title.lower():
-                    logger.info(f"Using Italian title from TMDB: '{it_title}'")
-                    return it_title
+        titles.append(title)
+        return self._unique_titles(titles)
 
-            except Exception as tmdb_exc:
-                logger.debug(f"Failed to get Italian title from TMDB: {tmdb_exc}")
+    def _resolve_radarr_title(self, title: str, movie_id: int, tmdb_id: Optional[int] = None) -> List[str]:
+        """Build ordered Radarr title candidates for VibraVid searches.
 
-        # Fallback: search all series by title (mirrors old Downloader.py)
-        try:
-            series_list = self.sonarr.get_series()
-            title_lower = title.lower()
-            for s in series_list:
-                s_title = s.get("title", "").lower()
-                s_slug = s.get("titleSlug", "").lower()
-                s_original = s.get("originalTitle", "").lower()
-                if title_lower in (s_title, s_slug, s_original):
-                    original = s.get("originalTitle")
-                    if original and original.lower() != title_lower:
-                        logger.info(f"Using original title from Sonarr (fallback): '{original}'")
-                        return original
-                    break
-        except Exception as exc:
-            logger.debug(f"Sonarr series list fallback failed: {exc}")
-
-        return None
-
-    def _resolve_radarr_title(self, movie_id: int, tmdb_id: Optional[int] = None) -> Optional[str]:
-        """Try to get the original title from Radarr.
-
-        If the original title is non-ASCII (e.g. Japanese/Korean/Chinese),
-        falls back to the Italian then English title from TMDB so that
-        StreamingCommunity can find it by a localized name.
+        Starts with Radarr's originalTitle and localized title, then adds TMDB
+        localized/alternative titles and finally the title from the ARR item.
+        This replaces the old single-title behavior while keeping the original
+        resolver name for callers.
         """
-        import re
-        import unicodedata
+        titles: List[Optional[str]] = []
 
-        original = None
         try:
             movie = self.radarr.get_movie_by_id(movie_id)
             original = movie.get("originalTitle")
-            if original:
-                logger.info(f"Using original title from Radarr: '{original}'")
+            radarr_title = movie.get("title")
+            logger.info(f"[_resolve_radarr_title] Radarr title='{radarr_title}', originalTitle='{original}'")
+            titles.extend([original, radarr_title])
         except Exception as exc:
             logger.debug(f"Radarr movie lookup by ID {movie_id} failed: {exc}")
 
-        # If original is fully non-ASCII, get a localised title from TMDB
-        if original and tmdb_id:
-            ascii_part = re.sub(r'\s+', '', unicodedata.normalize('NFKD', original)
-                                .encode('ascii', 'ignore').decode('ascii'))
-            if not ascii_part:
-                try:
-                    from VibraVid.provider.tmdb import tmdb_client as tmdb
-                    for lang in ["it", "en"]:
-                        details = tmdb._make_request(f"movie/{tmdb_id}", {"language": lang})
-                        loc_title = details.get("title", "")
-
-                        if loc_title and loc_title != original:
-                            logger.info(f"Non-ASCII original '{original}' → using {lang.upper()} TMDB title: '{loc_title}'")
-                            return loc_title
-
-                except Exception as tmdb_exc:
-                    logger.debug(f"TMDB localised title fallback failed: {tmdb_exc}")
-
-        return original
+        titles.extend(self._get_tmdb_title_candidates(tmdb_id, "movie"))
+        titles.append(title)
+        return self._unique_titles(titles)
 
     @staticmethod
     def _build_year_range(year) -> Optional[str]:
@@ -827,7 +869,7 @@ class ArrDownloaderService:
         folder = config_manager.config.get("OUTPUT", "movie_folder_name")
         return str(pathlib.Path(base).joinpath(folder, title))
 
-    def _get_vibrativo_serie_output(self, arr_series_path: str, search_title: str, season_num: int, year: Optional[int] = None) -> str:
+    def _get_vibrativo_serie_output(self, arr_series_path: str, title: str, season_num: int, year: Optional[int] = None) -> str:
         """Compute the VibraVid output path relative to Sonarr's root folder."""
         if not arr_series_path:
             return ""
@@ -837,7 +879,7 @@ class ArrDownloaderService:
 
             # Pass the year as string if available to match VibraVid's exact logic
             series_year = str(year) if year else None
-            path_components, _ = map_episode_path(series_name=search_title, series_year=series_year, season_number=season_num)
+            path_components, _ = map_episode_path(series_name=title, series_year=series_year, season_number=season_num)
 
             if "\\" in arr_series_path:
                 root = pathlib.PureWindowsPath(arr_series_path).parent
@@ -853,7 +895,7 @@ class ArrDownloaderService:
             logger.debug(f"Could not compute VibraVid serie output path: {exc}")
         return ""
 
-    def _get_vibrativo_movie_output(self, arr_movie_path: str, search_title: str, year: Optional[int] = None) -> str:
+    def _get_vibrativo_movie_output(self, arr_movie_path: str, title: str, year: Optional[int] = None) -> str:
         """Compute the VibraVid output path relative to Radarr's root folder."""
         if not arr_movie_path:
             return ""
@@ -863,7 +905,7 @@ class ArrDownloaderService:
 
             # Pass the year as string if available
             title_year = str(year) if year else None
-            path_components, _ = map_movie_path(title_name=search_title, title_year=title_year)
+            path_components, _ = map_movie_path(title_name=title, title_year=title_year)
 
             if "\\" in arr_movie_path:
                 root = pathlib.PureWindowsPath(arr_movie_path).parent

--- a/GUI/searchapp/arr/downloader_service.py
+++ b/GUI/searchapp/arr/downloader_service.py
@@ -561,6 +561,7 @@ class ArrDownloaderService:
                         (
                             r for r in results
                             if self._normalize_title(r.name or "") == expected_season_title
+                            or self._normalize_title(r.name or "").startswith(expected_season_title + " ")
                         ),
                         None,
                     )
@@ -570,6 +571,12 @@ class ArrDownloaderService:
                             f"[search] ACCEPT '{season_best.name}' — "
                             f"season-specific anime match for S{season_int}"
                         )
+                    else:
+                        logger.warning(
+                            f"[search] No season-specific anime result for S{season_int} "
+                            f"on '{provider}', rejecting generic results"
+                        )
+                        return None
 
             for r in results:
                 if best is not None:
@@ -706,6 +713,7 @@ class ArrDownloaderService:
                      and (
                          expected_season_title is None
                          or self._normalize_title((r.name or "").replace("(ITA)", "")) == expected_season_title
+                         or self._normalize_title((r.name or "").replace("(ITA)", "")).startswith(expected_season_title + " ")
                      )),
                     None,
                 )

--- a/GUI/searchapp/arr/processor_service.py
+++ b/GUI/searchapp/arr/processor_service.py
@@ -117,6 +117,7 @@ class ArrProcessorService:
                 "tags": elem["series"]["tags"],
                 "year": elem["series"].get("year"),
                 "tmdbId": elem["series"].get("tmdbId"),
+                "monitored": elem["series"].get("monitored", True),
                 "seasons": [],
             }
             base.append(serie)
@@ -132,6 +133,7 @@ class ArrProcessorService:
             "seasonNumber": elem["seasonNumber"],
             "episodeNumber": elem["episodeNumber"],
             "absoluteEpisodeNumber": elem.get("absoluteEpisodeNumber"),
+            "monitored": elem.get("monitored", True),
         })
 
     # ── Radarr ───────────────────────────────────────────
@@ -150,6 +152,7 @@ class ArrProcessorService:
                     "path": elem["path"],
                     "tags": elem["tags"],
                     "tmdbId": elem.get("tmdbId"),
+                    "monitored": elem.get("monitored", True),
                     "provider": self._extract_provider(elem["tags"], "radarr"),
                 })
 

--- a/GUI/searchapp/context_processors.py
+++ b/GUI/searchapp/context_processors.py
@@ -18,3 +18,31 @@ def active_downloads_context(request):
     return {
         'active_downloads_count': len(active_downloads),
     }
+
+
+def arr_stack_context(request):
+    """Expose whether the ARR queue entry should appear in navigation."""
+    try:
+        from .arr.arr_service import _load_arr_config
+
+        cfg = _load_arr_config()
+        arr_enabled = bool(cfg.get("enabled"))
+        sonarr_cfg = cfg.get("sonarr", {}) or {}
+        radarr_cfg = cfg.get("radarr", {}) or {}
+
+        has_sonarr = bool(sonarr_cfg.get("url") and sonarr_cfg.get("api_key"))
+        has_radarr = bool(radarr_cfg.get("url") and radarr_cfg.get("api_key"))
+        has_seerr = bool(cfg.get("enable_seerr_webhook"))
+        has_native_webhook = bool(
+            cfg.get("enable_sonarr_webhook") or cfg.get("enable_radarr_webhook")
+        )
+
+        show_arr_stack_nav = arr_enabled and (
+            has_sonarr or has_radarr or has_seerr or has_native_webhook
+        )
+    except Exception:
+        show_arr_stack_nav = False
+
+    return {
+        "show_arr_stack_nav": show_arr_stack_nav,
+    }

--- a/GUI/searchapp/templates/searchapp/arr_stack.html
+++ b/GUI/searchapp/templates/searchapp/arr_stack.html
@@ -1,0 +1,238 @@
+{% extends "searchapp/base.html" %}
+
+{% block title %}Coda ARR VibraVid{% endblock %}
+
+{% block content %}
+<div class="py-8 sm:py-12 animate-fade-in">
+  <div class="flex flex-col lg:flex-row items-start lg:items-center justify-between gap-6 mb-8">
+    <div>
+      <h1 class="text-3xl sm:text-4xl font-bold text-white mb-2">
+        Coda <span class="text-red-500">ARR</span>
+      </h1>
+      <p class="text-gray-400">
+        Item presi in carico da VibraVid tramite Sonarr, Radarr, webhook e polling.
+      </p>
+    </div>
+
+    <div class="flex flex-wrap items-center gap-3">
+      <span class="box-border h-10 px-3 py-0 rounded-lg border inline-flex items-center {% if arr_enabled %}border-green-500/40 bg-green-500/10 text-green-300{% else %}border-gray-700 bg-gray-900 text-gray-400{% endif %} text-sm font-semibold leading-5">
+        ARR {% if arr_enabled %}attivo{% else %}disattivo{% endif %}
+      </span>
+      <span class="box-border h-10 px-3 py-0 rounded-lg border inline-flex items-center {% if polling_enabled %}border-blue-500/40 bg-blue-500/10 text-blue-300{% else %}border-gray-700 bg-gray-900 text-gray-400{% endif %} text-sm font-semibold leading-5">
+        Polling {% if polling_enabled %}attivo{% else %}disattivo{% endif %}
+      </span>
+      <button
+        type="button"
+        id="arr-stack-sync-btn"
+        onclick="arrStackTriggerSync()"
+        class="box-border h-10 px-4 py-0 bg-blue-600 hover:bg-blue-700 border border-blue-600 hover:border-blue-700 disabled:opacity-60 disabled:cursor-wait text-white text-sm font-bold rounded-lg transition-colors inline-flex items-center justify-center gap-2 leading-5"
+      >
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
+        </svg>
+        <span>Sync manuale</span>
+      </button>
+    </div>
+  </div>
+
+  <div class="grid grid-cols-2 md:grid-cols-4 xl:grid-cols-7 gap-3 mb-8">
+    <div class="bg-gray-900/60 border border-gray-800 rounded-lg p-4">
+      <span class="text-[10px] font-bold uppercase tracking-widest text-gray-500 block mb-1">Totale</span>
+      <span class="text-2xl font-black text-white">{{ total_count }}</span>
+    </div>
+    <div class="bg-gray-900/60 border border-gray-800 rounded-lg p-4">
+      <span class="text-[10px] font-bold uppercase tracking-widest text-gray-500 block mb-1">Attivi</span>
+      <span class="text-2xl font-black text-blue-300">{{ active_count }}</span>
+    </div>
+    <div class="bg-gray-900/60 border border-gray-800 rounded-lg p-4">
+      <span class="text-[10px] font-bold uppercase tracking-widest text-gray-500 block mb-1">Pending</span>
+      <span class="text-2xl font-black text-yellow-300">{{ status_counts.pending|default:"0" }}</span>
+    </div>
+    <div class="bg-gray-900/60 border border-gray-800 rounded-lg p-4">
+      <span class="text-[10px] font-bold uppercase tracking-widest text-gray-500 block mb-1">Download</span>
+      <span class="text-2xl font-black text-blue-300">{{ status_counts.downloading|default:"0" }}</span>
+    </div>
+    <div class="bg-gray-900/60 border border-gray-800 rounded-lg p-4">
+      <span class="text-[10px] font-bold uppercase tracking-widest text-gray-500 block mb-1">Completati</span>
+      <span class="text-2xl font-black text-green-300">{{ status_counts.completed|default:"0" }}</span>
+    </div>
+    <div class="bg-gray-900/60 border border-gray-800 rounded-lg p-4">
+      <span class="text-[10px] font-bold uppercase tracking-widest text-gray-500 block mb-1">Falliti</span>
+      <span class="text-2xl font-black text-red-300">{{ status_counts.failed|default:"0" }}</span>
+    </div>
+    <div class="bg-gray-900/60 border border-gray-800 rounded-lg p-4">
+      <span class="text-[10px] font-bold uppercase tracking-widest text-gray-500 block mb-1">Saltati</span>
+      <span class="text-2xl font-black text-gray-300">{{ status_counts.skipped|default:"0" }}</span>
+    </div>
+  </div>
+
+  <p id="arr-stack-sync-message" class="hidden mb-4 text-sm"></p>
+
+  <form method="get" class="bg-gray-900/60 border border-gray-800 rounded-lg p-4 mb-6">
+    <div class="grid grid-cols-1 md:grid-cols-[1fr_auto_auto_auto_auto] gap-3 items-center">
+      <input
+        type="search"
+        name="q"
+        value="{{ filters.q }}"
+        placeholder="Cerca titolo, provider, ID o dedup key"
+        class="box-border h-10 px-3 py-0 rounded-lg bg-black/40 border border-gray-700 text-white placeholder:text-gray-500 focus:outline-none focus:border-red-500 leading-5"
+      >
+      <select name="status" class="box-border h-10 px-3 py-0 rounded-lg bg-black/40 border border-gray-700 text-white focus:outline-none focus:border-red-500 leading-5">
+        <option value="all" {% if filters.status == "all" %}selected{% endif %}>Tutti gli stati</option>
+        {% for value,label in status_choices %}
+        <option value="{{ value }}" {% if filters.status == value %}selected{% endif %}>{{ label }}</option>
+        {% endfor %}
+      </select>
+      <select name="source" class="box-border h-10 px-3 py-0 rounded-lg bg-black/40 border border-gray-700 text-white focus:outline-none focus:border-red-500 leading-5">
+        <option value="all" {% if filters.source == "all" %}selected{% endif %}>Sonarr + Radarr</option>
+        <option value="sonarr" {% if filters.source == "sonarr" %}selected{% endif %}>Sonarr</option>
+        <option value="radarr" {% if filters.source == "radarr" %}selected{% endif %}>Radarr</option>
+      </select>
+      <select name="sync" class="box-border h-10 px-3 py-0 rounded-lg bg-black/40 border border-gray-700 text-white focus:outline-none focus:border-red-500 leading-5">
+        <option value="all" {% if filters.sync == "all" %}selected{% endif %}>Tutte le origini</option>
+        {% for value,label in sync_choices %}
+        <option value="{{ value }}" {% if filters.sync == value %}selected{% endif %}>{{ label }}</option>
+        {% endfor %}
+      </select>
+      <button type="submit" class="box-border h-10 px-5 py-0 bg-white hover:bg-gray-200 border border-white hover:border-gray-200 text-black font-bold rounded-lg transition-colors text-sm inline-flex items-center justify-center leading-5">
+        Filtra
+      </button>
+    </div>
+  </form>
+
+  <div class="mb-3 text-sm text-gray-500">
+    Mostrati {{ shown_count }} item{% if filtered_count > 300 %} (limite pagina: 300){% endif %}.
+  </div>
+
+  <div class="bg-gray-900/50 border border-gray-800 rounded-lg overflow-hidden">
+    {% if entries %}
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-gray-800">
+        <thead class="bg-black/30">
+          <tr>
+            <th class="px-4 py-3 text-left text-[10px] font-bold uppercase tracking-widest text-gray-500">Item</th>
+            <th class="px-4 py-3 text-left text-[10px] font-bold uppercase tracking-widest text-gray-500">Stato</th>
+            <th class="px-4 py-3 text-left text-[10px] font-bold uppercase tracking-widest text-gray-500">Origine</th>
+            <th class="px-4 py-3 text-left text-[10px] font-bold uppercase tracking-widest text-gray-500">Coda</th>
+            <th class="px-4 py-3 text-left text-[10px] font-bold uppercase tracking-widest text-gray-500">Date</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-800">
+          {% for entry in entries %}
+          {% with item=entry.media_request %}
+          <tr class="hover:bg-white/[0.03] transition-colors">
+            <td class="px-4 py-4 align-top">
+              <div class="font-bold text-white">{{ item.title }}</div>
+              <div class="text-xs text-gray-400 mt-1">
+                {% if item.content_type == "movie" %}Film{% else %}Serie{% endif %}
+                {% if item.year %} · {{ item.year }}{% endif %}
+                {% if item.season_number %} · S{{ item.season_number|stringformat:"02d" }}{% endif %}
+                {% if item.episode_number %}E{{ item.episode_number|stringformat:"02d" }}{% endif %}
+              </div>
+              <div class="text-xs text-gray-500 mt-2">
+                Provider: <span class="text-gray-300">{{ item.provider|default:"-" }}</span>
+              </div>
+            </td>
+            <td class="px-4 py-4 align-top">
+              <span class="inline-flex px-2 py-1 rounded-full text-xs font-bold
+                {% if item.status == "completed" %}bg-green-500/10 text-green-300 border border-green-500/30
+                {% elif item.status == "downloading" %}bg-blue-500/10 text-blue-300 border border-blue-500/30
+                {% elif item.status == "pending" %}bg-yellow-500/10 text-yellow-300 border border-yellow-500/30
+                {% elif item.status == "failed" %}bg-red-500/10 text-red-300 border border-red-500/30
+                {% elif item.status == "skipped" %}bg-gray-500/10 text-gray-300 border border-gray-500/30
+                {% else %}bg-purple-500/10 text-purple-300 border border-purple-500/30{% endif %}">
+                {{ item.get_status_display }}
+              </span>
+              <div class="text-xs text-gray-500 mt-2">
+                {% if entry.success == True %}Successo{% elif entry.success == False %}Chiuso senza successo{% else %}In corso / in attesa{% endif %}
+              </div>
+            </td>
+            <td class="px-4 py-4 align-top text-sm">
+              <div class="text-white font-semibold uppercase">{{ item.arr_source }}</div>
+              <div class="text-xs text-gray-400 mt-1">{{ item.get_sync_source_display }}</div>
+              <div class="text-xs text-gray-500 mt-2">
+                ARR ID: {{ item.arr_id }}{% if item.episode_id %} · Ep ID: {{ item.episode_id }}{% endif %}
+              </div>
+            </td>
+            <td class="px-4 py-4 align-top">
+              <code class="block max-w-[320px] truncate text-xs text-gray-300 bg-black/30 border border-gray-800 rounded px-2 py-1">{{ entry.dedup_key }}</code>
+              <div class="text-xs text-gray-500 mt-2">
+                TMDB: {{ item.tmdb_id|default:"-" }} · TVDB: {{ item.tvdb_id|default:"-" }}
+              </div>
+            </td>
+            <td class="px-4 py-4 align-top text-xs text-gray-400 whitespace-nowrap">
+              <div>Accodato: {{ entry.enqueued_at|date:"d/m/Y H:i" }}</div>
+              <div>Avviato: {% if entry.started_at %}{{ entry.started_at|date:"d/m/Y H:i" }}{% else %}-{% endif %}</div>
+              <div>Chiuso: {% if entry.completed_at %}{{ entry.completed_at|date:"d/m/Y H:i" }}{% else %}-{% endif %}</div>
+              <div>Aggiornato: {{ item.updated_at|date:"d/m/Y H:i" }}</div>
+            </td>
+          </tr>
+          {% endwith %}
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% else %}
+    <div class="py-16 text-center px-6">
+      <div class="w-14 h-14 mx-auto mb-4 rounded-full bg-gray-800 border border-gray-700 flex items-center justify-center">
+        <svg class="w-7 h-7 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8h14M5 12h14M5 16h10"></path>
+        </svg>
+      </div>
+      <h2 class="text-lg font-bold text-white mb-2">Nessun item nella coda ARR</h2>
+      <p class="text-gray-500">Quando VibraVid prende in carico richieste da Sonarr/Radarr, appariranno qui.</p>
+    </div>
+    {% endif %}
+  </div>
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script>
+  function getArrStackCookie(name) {
+    const value = document.cookie.match(`(^|;) ?${name}=([^;]*)(;|$)`);
+    return value ? value[2] : '';
+  }
+
+  function showArrStackSyncMessage(message, type) {
+    const el = document.getElementById('arr-stack-sync-message');
+    if (!el) return;
+    const colors = {
+      success: 'text-green-300',
+      error: 'text-red-300',
+      info: 'text-blue-300',
+    };
+    el.textContent = message;
+    el.className = `mb-4 text-sm ${colors[type] || colors.info}`;
+  }
+
+  async function arrStackTriggerSync() {
+    const btn = document.getElementById('arr-stack-sync-btn');
+    const label = btn ? btn.querySelector('span') : null;
+    const originalText = label ? label.textContent : '';
+
+    if (btn) btn.disabled = true;
+    if (label) label.textContent = 'Sync in corso...';
+    showArrStackSyncMessage('Sync manuale avviato...', 'info');
+
+    try {
+      const response = await fetch('{% url "arr_trigger_sync" %}', {
+        method: 'POST',
+        headers: { 'X-CSRFToken': getArrStackCookie('csrftoken') },
+      });
+      const data = await response.json();
+
+      if (!response.ok || data.status === 'error' || data.status === 'disabled') {
+        throw new Error(data.message || 'Impossibile avviare il sync');
+      }
+
+      showArrStackSyncMessage('Sync avviato in background. La pagina si aggiorna tra pochi secondi.', 'success');
+      setTimeout(() => window.location.reload(), 3000);
+    } catch (error) {
+      showArrStackSyncMessage(`Errore: ${error.message}`, 'error');
+      if (btn) btn.disabled = false;
+      if (label) label.textContent = originalText || 'Sync manuale';
+    }
+  }
+</script>
+{% endblock %}

--- a/GUI/searchapp/templates/searchapp/base.html
+++ b/GUI/searchapp/templates/searchapp/base.html
@@ -228,6 +228,27 @@
 						</svg>
 						Watchlist
 					</a>
+					{% if show_arr_stack_nav %}
+					<a
+						href="{% url 'arr_stack' %}"
+						class="text-sm font-medium text-gray-300 hover:text-white transition-colors flex items-center gap-2"
+					>
+						<svg
+							class="w-4 h-4"
+							fill="none"
+							stroke="currentColor"
+							viewBox="0 0 24 24"
+						>
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M5 8h14M5 12h14M5 16h10"
+							></path>
+						</svg>
+						Coda ARR
+					</a>
+					{% endif %}
 					<a
 						href="{% url 'settings_editor' %}"
 						class="text-sm font-medium text-gray-300 hover:text-white transition-colors flex items-center gap-2"
@@ -351,6 +372,27 @@
 						</svg>
 						Watchlist
 					</a>
+					{% if show_arr_stack_nav %}
+					<a
+						href="{% url 'arr_stack' %}"
+						class="flex items-center gap-3 px-4 py-3 text-sm font-medium text-gray-300 hover:text-white hover:bg-white/10 rounded-lg transition-colors"
+					>
+						<svg
+							class="w-5 h-5"
+							fill="none"
+							stroke="currentColor"
+							viewBox="0 0 24 24"
+						>
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M5 8h14M5 12h14M5 16h10"
+							></path>
+						</svg>
+						Coda ARR
+					</a>
+					{% endif %}
 					<a
 						href="{% url 'settings_editor' %}"
 						class="flex items-center gap-3 px-4 py-3 text-sm font-medium text-gray-300 hover:text-white hover:bg-white/10 rounded-lg transition-colors"

--- a/GUI/searchapp/templates/searchapp/settings_editor.html
+++ b/GUI/searchapp/templates/searchapp/settings_editor.html
@@ -632,6 +632,22 @@
     };
   }
 
+  function isPlainObject(value) {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+  }
+
+  function deepMergeConfig(base, updates) {
+    const merged = { ...(isPlainObject(base) ? base : {}) };
+    Object.entries(updates || {}).forEach(([key, value]) => {
+      if (isPlainObject(value) && isPlainObject(merged[key])) {
+        merged[key] = deepMergeConfig(merged[key], value);
+      } else {
+        merged[key] = value;
+      }
+    });
+    return merged;
+  }
+
   function resetArrForm() {
     populateArrForm(originalArrConfig);
     showMessage('arr', 'ARR settings ripristinati', 'info');
@@ -645,7 +661,7 @@
       try { fullConfig = JSON.parse(configEditor.value); } catch (e) {
         showMessage('arr', 'config.json non valido. Correggi prima.', 'error'); return;
       }
-      fullConfig.ARR = readArrForm();
+      fullConfig.ARR = deepMergeConfig(fullConfig.ARR, readArrForm());
       const content = JSON.stringify(fullConfig, null, 4);
       const response = await fetch('{% url "save_settings" %}', {
         method: 'POST',

--- a/GUI/searchapp/urls.py
+++ b/GUI/searchapp/urls.py
@@ -44,6 +44,7 @@ urlpatterns = [
     path("api/arr/webhook/radarr/", views.radarr_webhook, name="radarr_webhook"),
     path("api/arr/status/", views.arr_status, name="arr_status"),
     path("api/arr/trigger-sync/", views.arr_trigger_sync, name="arr_trigger_sync"),
+    path("arr-stack/", views.arr_stack, name="arr_stack"),
 
     # In-app update
     path("api/version/check/", views.check_updates, name="check_updates"),

--- a/GUI/searchapp/views.py
+++ b/GUI/searchapp/views.py
@@ -15,6 +15,7 @@ import importlib
 import concurrent.futures
 from typing import Any, Dict, List, Optional
 
+from django.db.models import Q
 from django.shortcuts import render, redirect
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.views.decorators.http import require_http_methods
@@ -24,7 +25,7 @@ from django.utils import timezone
 
 
 from .forms import SearchForm, DownloadForm
-from .models import WatchlistItem
+from .models import ArrMediaRequest, ArrProcessingQueue, WatchlistItem
 from .watchlist_auto import _get_interval_seconds
 from GUI.searchapp.api import get_api, get_available_sites, get_site_categories
 from GUI.searchapp.api.base import Entries
@@ -1617,6 +1618,62 @@ def save_settings(request: HttpRequest) -> JsonResponse:
 # ─────────────────────────────────────────────────────
 # ARR Integration Views
 # ─────────────────────────────────────────────────────
+
+@require_http_methods(["GET"])
+def arr_stack(request: HttpRequest) -> HttpResponse:
+    """Display VibraVid's internal queue for media accepted from ARR."""
+    from .arr.arr_service import _load_arr_config
+
+    cfg = _load_arr_config()
+    status_filter = request.GET.get("status", "all")
+    source_filter = request.GET.get("source", "all")
+    sync_filter = request.GET.get("sync", "all")
+    query = request.GET.get("q", "").strip()
+
+    queue_entries = ArrProcessingQueue.objects.select_related("media_request").order_by("-enqueued_at")
+    if status_filter != "all":
+        queue_entries = queue_entries.filter(media_request__status=status_filter)
+    if source_filter != "all":
+        queue_entries = queue_entries.filter(media_request__arr_source=source_filter)
+    if sync_filter != "all":
+        queue_entries = queue_entries.filter(media_request__sync_source=sync_filter)
+    if query:
+        queue_entries = queue_entries.filter(
+            Q(media_request__title__icontains=query)
+            | Q(dedup_key__icontains=query)
+            | Q(media_request__provider__icontains=query)
+            | Q(media_request__tmdb_id__icontains=query)
+            | Q(media_request__imdb_id__icontains=query)
+            | Q(media_request__tvdb_id__icontains=query)
+        )
+
+    status_counts = {
+        status: ArrMediaRequest.objects.filter(status=status).count()
+        for status, _ in ArrMediaRequest.Status.choices
+    }
+    active_count = ArrProcessingQueue.objects.filter(completed_at__isnull=True).count()
+    total_count = ArrProcessingQueue.objects.count()
+    filtered_count = queue_entries.count()
+
+    return render(request, "searchapp/arr_stack.html", {
+        "arr_enabled": cfg.get("enabled", False),
+        "polling_enabled": cfg.get("enable_polling", False),
+        "entries": queue_entries[:300],
+        "shown_count": min(filtered_count, 300),
+        "filtered_count": filtered_count,
+        "total_count": total_count,
+        "active_count": active_count,
+        "status_counts": status_counts,
+        "status_choices": ArrMediaRequest.Status.choices,
+        "sync_choices": ArrMediaRequest.SyncSource.choices,
+        "filters": {
+            "q": request.GET.get("q", "").strip(),
+            "status": request.GET.get("status", "all"),
+            "source": request.GET.get("source", "all"),
+            "sync": request.GET.get("sync", "all"),
+        },
+    })
+
 
 @csrf_exempt
 @require_http_methods(["POST"])

--- a/GUI/searchapp/views.py
+++ b/GUI/searchapp/views.py
@@ -472,6 +472,15 @@ def _run_download_in_thread(site: str, item_payload: Dict[str, Any], season: str
                 api.start_download(media_item, season=season, episodes=episodes, audio_format=audio_format)
             except TypeError:
                 api.start_download(media_item, season=season, episodes=episodes)
+
+            final_state = next(
+                (item for item in download_tracker.get_history() if item.get("id") == download_id),
+                None,
+            )
+            if final_state and final_state.get("status") in {"failed", "cancelled", "timed_out"}:
+                error_msg = final_state.get("error") or final_state.get("status") or "download_failed"
+                raise RuntimeError(error_msg)
+
             print("[_task] ✓ Download completed successfully")
         except Exception as e:
             error_msg = str(e) or "Errore sconosciuto"
@@ -482,11 +491,18 @@ def _run_download_in_thread(site: str, item_payload: Dict[str, Any], season: str
             try:
                 _remove_scheduled_download(download_id)
 
-                # start it briefly just to mark it as failed in the history.
-                if download_id not in download_tracker.downloads:
+                already_in_history = any(
+                    item.get("id") == download_id
+                    for item in download_tracker.get_history()
+                )
+
+                # Start it briefly only when nothing downstream already wrote
+                # the final state to the tracker.
+                if download_id not in download_tracker.downloads and not already_in_history:
                     download_tracker.start_download(download_id, title, site, media_type)
 
-                download_tracker.complete_download(download_id, success=False, error=error_msg)
+                if not already_in_history:
+                    download_tracker.complete_download(download_id, success=False, error=error_msg)
             except Exception as tracker_err:
                 print(f"[Error] Failed to update download tracker: {tracker_err}")
             raise

--- a/GUI/webgui/settings.py
+++ b/GUI/webgui/settings.py
@@ -91,6 +91,7 @@ TEMPLATES = [
                 "django.contrib.messages.context_processors.messages",
                 "searchapp.context_processors.version_context",
                 "searchapp.context_processors.active_downloads_context",
+                "searchapp.context_processors.arr_stack_context",
             ],
         },
     },

--- a/VibraVid/core/muxing/helper/audio.py
+++ b/VibraVid/core/muxing/helper/audio.py
@@ -1,6 +1,7 @@
 # 16.04.24
 
 import os
+import base64
 import json
 import logging
 import subprocess
@@ -10,6 +11,7 @@ from typing import List, Optional
 
 from mutagen.mp4 import MP4, MP4Cover
 from mutagen.flac import FLAC, Picture
+from mutagen.oggopus import OggOpus
 from mutagen.id3 import (
     ID3, ID3NoHeaderError,
     TIT2, TPE1, TALB, TDRC, TRCK, APIC, TCON,
@@ -230,6 +232,39 @@ def _tag_mp4(path: Path, title: str, artist: str, album: str, year: str, track_n
     audio.save()
 
 
+def _tag_opus(path: Path, title: str, artist: str, album: str, year: str, track_number: Optional[int], genre: str, cover_url: Optional[str]) -> None:
+    """Write Vorbis comment tags + cover art to an Opus file."""
+    audio = OggOpus(str(path))
+    if audio.tags is None:
+        audio.add_tags()
+
+    audio['title'] = [title]
+    audio['artist'] = [artist]
+    if album:
+        audio['album'] = [album]
+    if year:
+        audio['date'] = [str(year)]
+    if track_number is not None:
+        audio['tracknumber'] = [str(track_number)]
+    if genre:
+        audio['genre'] = [genre]
+
+    if cover_url:
+        cover_data = _fetch_cover(cover_url)
+        if cover_data:
+            pic = Picture()
+            pic.type = 3
+            pic.mime = 'image/jpeg'
+            pic.desc = 'Cover'
+            pic.data = cover_data
+            audio['metadata_block_picture'] = [base64.b64encode(pic.write()).decode('ascii')]
+            logger.info("Cover art embedded (Opus): %s", cover_url)
+        else:
+            logger.warning("Cover download returned empty bytes (Opus)")
+
+    audio.save()
+
+
 def _tag_mp3(path: Path, title: str, artist: str, album: str, year: str, track_number: Optional[int], genre: str, cover_url: Optional[str]) -> None:
     """Write ID3 tags + cover art to an MP3 file."""
     try:
@@ -297,6 +332,9 @@ def tag_track(file_path: str, title: str, artist: str, album: str = "", year: st
 
         elif suffix == '.mp3':
             _tag_mp3(path, title, artist, album, year, track_number, genre, cover_url)
+
+        elif suffix == '.opus':
+            _tag_opus(path, title, artist, album, year, track_number, genre, cover_url)
 
         else:
             # .m4a, .mp4, .aac, …
@@ -421,6 +459,13 @@ def process_song(file_path: str, title: str, artist: str, album: str = "", year:
             logger.info(f"Removed original file: {path}")
         except Exception as e:
             logger.warning(f"Could not remove original file: {e}")
+
+        # Re-tag converted file: ffmpeg transfers text tags but not picture blocks (e.g. opus)
+        tag_track(
+            file_path=converted,
+            title=title, artist=artist, album=album, year=year,
+            track_number=track_number, genre=genre, cover_url=cover_url,
+        )
 
     print("\n")
     return converted

--- a/VibraVid/core/utils/codec.py
+++ b/VibraVid/core/utils/codec.py
@@ -1,59 +1,63 @@
 # 13.03.26
 
 VIDEO_CODEC_MAP: dict[str, str] = {
-    "avc1": "H.264",
-    "h264": "H.264",
-    "x264": "H.264",
-    "hvc1": "H.265",
-    "hev1": "H.265",
-    "hevc": "H.265",
-    "h265": "H.265",
-    "x265": "H.265",
-    "vp8":  "VP8",
-    "vp80": "VP8",
-    "vp9":  "VP9",
-    "vp09": "VP9",
-    "vp90": "VP9",
-    "av1":  "AV1",
-    "av01": "AV1",
-    "dvhe": "Dolby Vision",
-    "dvh1": "Dolby Vision",
-    "dvav": "Dolby Vision",
-    "dav1": "Dolby Vision",
-    "mp4v": "MPEG-4",
-    "mpeg4": "MPEG-4",
-    "vc1":   "VC-1",
-    "wmv3":  "WMV",
-    "mjpeg": "MJPEG",
-    "prores": "ProRes",
+    "avc1":     "H.264",
+    "h264":     "H.264",
+    "x264":     "H.264",
+    "hvc1":     "H.265",
+    "hev1":     "H.265",
+    "hevc":     "H.265",
+    "h265":     "H.265",
+    "x265":     "H.265",
+    "vp8":      "VP8",
+    "vp80":     "VP8",
+    "vp9":      "VP9",
+    "vp09":     "VP9",
+    "vp90":     "VP9",
+    "av1":      "AV1",
+    "av01":     "AV1",
+    "dvhe":     "Dolby Vision",
+    "dvh1":     "Dolby Vision",
+    "dvav":     "Dolby Vision",
+    "dav1":     "Dolby Vision",
+    "mp4v":     "MPEG-4",
+    "mpeg4":    "MPEG-4",
+    "vc1":      "VC-1",
+    "wmv3":     "WMV",
+    "mjpeg":    "MJPEG",
+    "prores":   "ProRes",
 }
 
 AUDIO_CODEC_MAP: dict[str, str] = {
-    "mp4a":      "AAC",
-    "aac":       "AAC",
-    "mp3":       "MP3",
-    "mp4a.69":   "MP3",
-    "mp4a.6b":   "MP3",
-    "opus":      "Opus",
-    "vorbis":    "Vorbis",
-    "vorb":      "Vorbis",
-    "ac3":       "AC-3",
-    "ac-3":      "AC-3",
-    "eac3":      "E-AC-3",
-    "ec-3":      "E-AC-3",
-    "dts":       "DTS",
-    "dtsc":      "DTS",
-    "dtse":      "DTS",
-    "dtsh":      "DTS",
-    "flac":      "FLAC",
-    "alac":      "ALAC",
-    "pcm":       "PCM",
-    "lpcm":      "PCM",
-    "pcm_s16le": "PCM",
-    "wma":       "WMA",
-    "wmav2":     "WMA",
-    "amr":       "AMR",
-    "speex":     "Speex",
+    "mp4a":          "AAC",
+    "aac":           "AAC",
+    "mp3":           "MP3",
+    "mp4a.69":       "MP3",
+    "mp4a.6b":       "MP3",
+    "opus":          "Opus",
+    "vorbis":        "Vorbis",
+    "vorb":          "Vorbis",
+    "ac3":           "AC-3",
+    "ac-3":          "AC-3",
+    "eac3":          "E-AC-3",
+    "ec-3":          "E-AC-3",
+    "dts":           "DTS",
+    "dtsc":          "DTS",
+    "dtse":          "DTS",
+    "dtsh":          "DTS",
+    "flac":          "FLAC",
+    "alac":          "ALAC",
+    "pcm":           "PCM",
+    "lpcm":          "PCM",
+    "pcm_s16le":     "PCM",
+    "wma":           "WMA",
+    "wmav2":         "WMA",
+    "amr":           "AMR",
+    "speex":         "Speex",
+    "ac-4":          "AC-4",
+    "ac4":           "AC-4",
+    "ac-4.02.02.00": "AC-4",
+    "mp4a.ac-4":     "AC-4",
 }
 
 SUBTITLE_CODEC_MAP: dict[str, str] = {
@@ -77,7 +81,6 @@ CHANNEL_MAP: dict[str, str] = {
     "4":    "4.0",
     "6":    "5.1",
     "8":    "7.1",
-    # DASH AudioChannelConfiguration hex codes
     "A000": "Stereo",
     "A001": "Mono",
     "A002": "2.1",
@@ -89,22 +92,24 @@ CHANNEL_MAP: dict[str, str] = {
 
 
 SUBTITLE_CODEC_PREFIXES: tuple[str, ...] = (
-    "wvtt",        # WebVTT in ISOBMFF
-    "stpp",        # TTML (Synchronized Timed Text)
-    "ttml",        # TTML plain
-    "vtt",         # WebVTT plain
-    "webvtt",      # WebVTT variant
-    "srt",         # SubRip
-    "tx3g",        # QuickTime/MP4 text
-    "ass",         # Advanced SubStation Alpha
-    "ssa",         # SubStation Alpha
-    "dfxp",        # Distribution Format Exchange Profile (TTML)
+    "wvtt",
+    "stpp",
+    "ttml",
+    "vtt",
+    "webvtt",
+    "srt",
+    "tx3g",
+    "ass",
+    "ssa",
+    "dfxp"
 )
 
 AUDIO_CODEC_PREFIXES: tuple[str, ...] = (
-    "mp4a",    # AAC variants
-    "ec-3",    # E-AC-3 / Dolby Digital Plus
-    "ac-3",    # AC-3 / Dolby Digital
+    "mp4a",
+    "ec-3",
+    "ac-4",
+    "ac4",
+    "ac-3",
     "ac3",
     "eac3",
     "opus",
@@ -112,28 +117,28 @@ AUDIO_CODEC_PREFIXES: tuple[str, ...] = (
     "vorb",
     "flac",
     "alac",
-    "dtsc",    # DTS Core
-    "dtse",    # DTS Express
-    "dtsh",    # DTS-HD
+    "dtsc",
+    "dtse",
+    "dtsh",
     "dts",
     "pcm",
     "lpcm",
-    "wma",
+    "wma"
 )
 
 VIDEO_CODEC_PREFIXES: tuple[str, ...] = (
-    "avc",     # H.264 / AVC  (also matches avc1.*)
-    "hvc",     # H.265 / HEVC (hvc1.*)
-    "hev",     # H.265 variant (hev1.*)
+    "avc",
+    "hvc",
+    "hev",
     "hevc",
-    "av01",    # AV1
-    "vp09",    # VP9
-    "vp08",    # VP8
-    "dvhe",    # Dolby Vision HEVC
-    "dvh1",    # Dolby Vision HEVC (HVCL)
-    "dvav",    # Dolby Vision AVC
-    "dav1",    # Dolby Vision AV1
-    "mp4v",    # MPEG-4 Visual
+    "av01",
+    "vp09",
+    "vp08",
+    "dvhe",
+    "dvh1",
+    "dvav",
+    "dav1",
+    "mp4v",
     "vc-1",
     "vc1",
 )
@@ -193,6 +198,7 @@ CODEC_EXTENSION_MAP: dict[str, str] = {
     "mp4a":  "m4a",
     "ec-3":  "m4a",
     "ac-3":  "m4a",
+    "ac-4":  "m4a",
     "opus":  "webm",
     "flac":  "flac",
     "alac":  "m4a",
@@ -259,6 +265,8 @@ _AUDIO_CODEC_TOKEN: dict[str, str] = {
     "flac":     "flac",
     "alac":     "alac",
     "dts":      "dtsc",
+    "ac4":      "ac-4",
+    "ac-4":     "ac-4",
 }
 
 
@@ -290,18 +298,18 @@ def get_short_codec(stream_type: str, codec_str: str) -> str:
     """Return human-readable codec name given a stream type and codec string."""
     if not codec_str:
         return ""
-    
+
     # Check if it's a composite codec string (contains comma)
     if ',' in codec_str:
         codec_parts = [part.strip() for part in codec_str.split(',')]
-        
+
         # Convert each codec based on its detected type
         converted: list[str] = []
         seen_set: set[str] = set()
-        
+
         for part in codec_parts:
             detected_type = detect_stream_type(part)
-            
+
             # Choose the appropriate codec map
             if detected_type == "video":
                 codec_map = VIDEO_CODEC_MAP
@@ -320,20 +328,20 @@ def get_short_codec(stream_type: str, codec_str: str) -> str:
                     codec_map = SUBTITLE_CODEC_MAP
                 else:
                     codec_map = VIDEO_CODEC_MAP
-            
+
             # Translate the codec
             translated = _lookup(codec_map, part)
-            
+
             # Avoid duplicates (e.g., multiple "H.265" entries)
             if translated and translated not in seen_set:
                 converted.append(translated)
                 seen_set.add(translated)
-        
+
         # If all conversions succeeded, return joined result
         if converted:
             return ", ".join(converted)
         return codec_str
-    
+
     # Single codec - use original logic
     t = stream_type.lower()
     if t == "video":

--- a/VibraVid/services/animeunity/downloader.py
+++ b/VibraVid/services/animeunity/downloader.py
@@ -81,6 +81,30 @@ def download_episode(obj_episode, index_select, scrape_serie, video_source):
     else:
         return HLS_Downloader(m3u8_url=video_source.master_playlist, output_path=os.path.join(mp4_path, f"{mp4_name}.{extension_output}")).start()
 
+
+def _get_episode_by_number_or_index(scrape_serie, episode_number: int):
+    """Return the episode whose provider number matches, falling back to list index.
+
+    AnimeUnity episode lists can contain entries whose displayed episode number
+    does not match their zero-based position, so ARR's explicit episode number
+    should be matched against the provider metadata first.
+    """
+    if getattr(scrape_serie, "episodes_cache", None) is None:
+        scrape_serie._fetch_all_episodes()
+
+    for index, episode in enumerate(scrape_serie.episodes_cache or []):
+        raw_number = episode.get("number")
+        try:
+            current_number = int(float(str(raw_number).split("-")[0]))
+        except (TypeError, ValueError):
+            continue
+        if current_number == episode_number:
+            return scrape_serie.get_info_episode(index), index
+
+    fallback_index = episode_number - 1
+    return scrape_serie.get_info_episode(fallback_index), fallback_index
+
+
 def download_series(select_title: Entries, season_selection: str = None, episode_selection: str = None, scrape_serie = None):
     """
     Handle downloading a complete series.
@@ -121,8 +145,10 @@ def download_series(select_title: Entries, season_selection: str = None, episode
 
     # Download selected episodes
     if len(list_episode_select) == 1 and last_command != "*":
-        obj_episode = scrape_serie.get_info_episode(list_episode_select[0]-1)
-        path, _, msg_error = unpack_download_result(download_episode(obj_episode, list_episode_select[0]-1, scrape_serie, video_source))
+        obj_episode, index_select = _get_episode_by_number_or_index(scrape_serie, list_episode_select[0])
+        if obj_episode is None:
+            return None, False, f"Episode {list_episode_select[0]} not found"
+        path, _, msg_error = unpack_download_result(download_episode(obj_episode, index_select, scrape_serie, video_source))
 
         if msg_error:
             console.print(f"[red]{msg_error}")
@@ -136,8 +162,13 @@ def download_series(select_title: Entries, season_selection: str = None, episode
             if kill_handler:
                 break
             
-            obj_episode = scrape_serie.get_info_episode(i_episode-1)
-            _, kill_handler, msg_error = unpack_download_result(download_episode(obj_episode, i_episode-1, scrape_serie, video_source))
+            obj_episode, index_select = _get_episode_by_number_or_index(scrape_serie, i_episode)
+            if obj_episode is None:
+                console.print(f"[red]Episode {i_episode} not found")
+                kill_handler = True
+                continue
+
+            _, kill_handler, msg_error = unpack_download_result(download_episode(obj_episode, index_select, scrape_serie, video_source))
 
             if msg_error:
                 console.print(f"[red]{msg_error}")


### PR DESCRIPTION
## Summary

This PR improves the *ARR integration flow by making VibraVid’s internal ARR queue visible in the web UI, improving monitored/unmonitored handling for Sonarr/Radarr items, and tightening error propagation between VibraVid downloads and ARR queue state.

## Changes

### ARR queue UI

- Added a new **Coda ARR** page to inspect VibraVid’s internal ARR processing queue.
- The page shows queued ARR items with status, source, sync origin, provider, IDs, timestamps, and completion state.
- Added filters for:
  - queue status
  - Sonarr/Radarr source
  - sync source
  - free text search
- Added a manual ARR sync button from the queue page.
- Added navigation entry visibility logic so **Coda ARR** appears only when ARR is enabled/configured.
- Adjusted UI alignment and control sizing in the ARR queue page.

### ARR monitored/unmonitored handling

- Added live checks for Radarr movie monitored state before processing.
- Added live checks for Sonarr series and episode monitored state before downloading episodes.
- Pending ARR queue entries are reconciled and skipped when the related Sonarr/Radarr item becomes unmonitored.
- Added protections so items marked unmonitored after enqueue but before actual processing are skipped instead of downloaded.

### ARR download and queue state consistency

- Improved propagation of failed VibraVid downloads back to ARR processing.
- `_run_download_in_thread()` now checks the final `DownloadTracker` state after `api.start_download()`.
- If the GUI download tracker marks a download as failed/cancelled/timed out, the future now raises an error so ARR can mark the queue entry as failed.
- Avoided duplicate download history entries when downstream code already wrote the final tracker state.

### ARR search improvements

- Improved ARR title fallback search for Sonarr/Radarr requests.
- Added better fallback handling for localized/original titles and provider-specific title matching.
- Improved season-specific anime search behavior and logging when no results are found.

### AnimeUnity episode resolution

- Updated AnimeUnity downloader episode selection to resolve episodes by provider episode number instead of relying only on list index.
- This makes episode matching more reliable when provider ordering/indexing differs from expected episode numbers.

### Settings editor fix

- Fixed ARR settings save behavior so the **ARR Integration** tab no longer overwrites unrelated ARR config JSON values.
