### PR TITLE
fix: sync last_season_episodes in watchlist auto-download loop

### DIFF
--- a/GUI/searchapp/watchlist_auto.py
+++ b/GUI/searchapp/watchlist_auto.py
@@ -99,6 +99,9 @@ def _process_item(item: WatchlistItem, force: bool = False) -> None:
             item.auto_last_downloaded_at = now
             item.has_new_episodes = True
 
+        # Keep display fields in sync with the live metadata already fetched
+        item.num_seasons = len(seasons)
+        item.last_season_episodes = seasons[-1].episode_count
         item.auto_last_checked_at = now
         item.last_checked_at = now
         item.save(
@@ -108,6 +111,8 @@ def _process_item(item: WatchlistItem, force: bool = False) -> None:
                 "auto_last_downloaded_at",
                 "has_new_episodes",
                 "last_checked_at",
+                "num_seasons",
+                "last_season_episodes",
             ]
         )
     except Exception as exc:


### PR DESCRIPTION
## Bug description

When the auto-download loop detects a new episode (e.g. episode 5 of a season), the watchlist card still displays the old episode count (e.g. 4) until the user manually triggers a refresh or navigates to the series detail page and back.

The green **NUOVA USCITA!** badge appears correctly, but **Episodi Ultima** shows the stale count.

## Root cause

In `GUI/searchapp/watchlist_auto.py`, `_process_item()` already fetches full season metadata from the API and stores the new episode count into `auto_last_episode_count`. However, it does **not** update `last_season_episodes` or `num_seasons` — the two fields rendered on the watchlist card.

Because `last_checked_at` is saved, the JS polling loop on the watchlist page triggers a reload, but the freshly-loaded page still reads the stale `last_season_episodes` value from the database.

`_update_single_item()` (in `views.py`) does update both fields correctly, but it is only called when the user manually clicks the per-item refresh button (⟳) or **Aggiorna Tutte** — not by the auto-download loop.

## Fix

In `_process_item()`, after the season metadata is already in memory, sync `num_seasons` and `last_season_episodes` before saving:

```python
# Keep display fields in sync with the live metadata already fetched
item.num_seasons = len(seasons)
item.last_season_episodes = seasons[-1].episode_count
item.auto_last_checked_at = now
item.last_checked_at = now
item.save(
    update_fields=[
        "auto_last_episode_count",
        "auto_last_checked_at",
        "auto_last_downloaded_at",
        "has_new_episodes",
        "last_checked_at",
        "num_seasons",
        "last_season_episodes",  # ← add this
    ]
)
```

No extra API call is needed — `seasons` is already fetched a few lines earlier.

## Steps to reproduce

1. Add a TV series to the watchlist and enable auto-download for its latest season.
2. Wait for a new episode to be released and for the auto-download loop to run.
3. Open the watchlist page — the episode count shown in the card is the old value even though the **NUOVA USCITA!** badge is visible.
4. Click **Dettagli Serie** and navigate back — the count now updates (coinciding with a manual refresh completing in the background).

## Environment

- VibraVid 1.3.1 (stock Docker image)
- Self-hosted on Synology NAS via Docker Compose
