### PR TITLE
Fix: Bypass vault caching to allow dynamic key resolution

### DIFF
--- a/Conf/config.json
+++ b/Conf/config.json
@@ -27,6 +27,8 @@
         "delay_after_download": 0,
         "skip_download": false,
         "thread_count": 12,
+        "segment_delay_seconds": 0,
+        "segment_delay_jitter_seconds": 0,
         "decrypt_worker_count": 8,
         "subtitle_resolve_workers": 4,
         "realtime_decrypt": true,
@@ -75,6 +77,7 @@
     "DRM": {
         "use_cdm": true,
         "prefer_remote_cdm": false,
+        "bypass_vault_cache": false,
         "vault": {
             "supa": {
                 "url": "https://drm-db.server66.workers.dev",

--- a/GUI/searchapp/api/__init__.py
+++ b/GUI/searchapp/api/__init__.py
@@ -15,6 +15,7 @@ _PREFERRED_ORDER = [
     'animeunity',
     'animeworld',
     'crunchyroll',
+    'primevideo',
     'mediasetinfinity',
     'raiplay',
     'discoveryplus',
@@ -28,6 +29,7 @@ _PREFERRED_ORDER = [
     'cinezo',
     'mostraguarda',
     'eurostreaming',
+    'amazon_music'
 ]
 _SITE_CATEGORIES: Dict[str, str] = {}
 
@@ -40,7 +42,7 @@ def _initialize_registry():
     package_dir = os.path.dirname(__file__)
     api_files = [
         f[:-3] for f in os.listdir(package_dir)
-        if f.endswith('.py') and f not in ('base.py', '__init__.py')
+        if f.endswith('.py') and f not in ('base.py', '__init__.py', 'generic.py')
     ]
 
     # Use preferred order first, then any remaining files
@@ -63,11 +65,14 @@ def _initialize_registry():
             for name, obj in module.__dict__.items():
                 if (isinstance(obj, type) and
                     issubclass(obj, BaseStreamingAPI) and
-                    obj is not BaseStreamingAPI):
+                    obj is not BaseStreamingAPI and
+                    obj.__module__ == module.__name__):
                     api_cls = obj
                     break
+
             if api_cls is None:
                 raise RuntimeError("no BaseStreamingAPI subclass found in module")
+            
             api_cls._indice = idx
             new_registry[module_name] = api_cls
         except Exception as e:

--- a/GUI/searchapp/api/amazon_music.py
+++ b/GUI/searchapp/api/amazon_music.py
@@ -1,0 +1,140 @@
+# 11.07.26
+
+import importlib
+import logging
+from typing import List, Optional
+
+from .base import BaseStreamingAPI, Entries, Season, Episode
+
+from VibraVid.services._base.site_loader import get_folder_name
+
+
+logger = logging.getLogger(__name__)
+
+
+class AmazonMusicAPI(BaseStreamingAPI):
+    def __init__(self):
+        super().__init__()
+        self.site_name = "amazon_music"
+        self._load_config()
+        self._search_fn = None
+
+    def _load_config(self):
+        """Load site configuration."""
+        self.base_url = None
+
+    def _get_search_fn(self):
+        """Lazy-load the service search function from the services package."""
+        if self._search_fn is None:
+            module = importlib.import_module(f"VibraVid.{get_folder_name()}.{self.site_name}")
+            self._search_fn = getattr(module, "search")
+        return self._search_fn
+
+    def _get_album_scraper(self, media_item: Entries):
+        """Build and fetch an AlbumScraper for an album Entries item."""
+        module = importlib.import_module(f"VibraVid.{get_folder_name()}.{self.site_name}.scrapper")
+        AlbumScraper = getattr(module, "AlbumScraper")
+
+        raw_data = media_item.raw_data if isinstance(media_item.raw_data, dict) else {}
+        raw_url = str(media_item.url or raw_data.get("url") or "").strip()
+        album_id = raw_url.split(":", 1)[1] if ":" in raw_url else raw_url
+        if not album_id:
+            album_id = str(media_item.id or raw_data.get("id") or "").strip()
+        if not album_id:
+            return None
+
+        audio_format = getattr(media_item, "audio_format", None)
+        scraper = AlbumScraper(album_id, audio_format=audio_format)
+        scraper._audio_format_raw = audio_format
+        scraper.fetch()
+        return scraper
+
+    def search(self, query: str) -> List[Entries]:
+        """Search for tracks and albums and return a list of Entries for the GUI."""
+        search_fn = self._get_search_fn()
+        database = search_fn(query, get_onlyDatabase=True)
+
+        results: List[Entries] = []
+        if database and hasattr(database, "media_list"):
+            for element in database.media_list:
+                item_dict = element.__dict__.copy() if hasattr(element, "__dict__") else {}
+
+                media_item = Entries(
+                    id=item_dict.get("id"),
+                    name=item_dict.get("name"),
+                    slug=item_dict.get("slug", ""),
+                    path_id=item_dict.get("path_id"),
+                    type=item_dict.get("type", "song"),   # "song" or "album"
+                    url=item_dict.get("url"),
+                    poster=item_dict.get("image"),
+                    year=item_dict.get("year"),
+                    tmdb_id=item_dict.get("tmdb_id"),
+                    raw_data=item_dict,
+                )
+                results.append(media_item)
+
+        return results
+
+    def get_series_metadata(self, media_item: Entries) -> Optional[List[Season]]:
+        """
+        For albums: build an AlbumScraper, cache it, and return its disc list as
+        Season objects so the GUI series_detail view works unchanged.
+        """
+        if str(getattr(media_item, "type", "")).lower() != "album":
+            return None
+
+        try:
+            scraper = self._get_album_scraper(media_item)
+            if scraper is None:
+                logger.warning("Amazon Music album metadata skipped: album_id not found for media item '%s'", media_item.name)
+                return None
+
+            # Cache the scraper so start_download can reuse it
+            self.set_cached_scraper(media_item, scraper)
+
+            seasons: List[Season] = []
+            for season_obj in scraper.seasons_manager.seasons:
+                disc_number = season_obj.number
+                episodes = scraper.getEpisodeSeasons(disc_number)
+
+                gui_season = Season(
+                    number=disc_number,
+                    name=season_obj.name,
+                    episodes=[
+                        Episode(
+                            number=ep.get("number") or (i + 1),
+                            name=ep.get("name", ""),
+                            id=ep.get("id"),
+                        )
+                        for i, ep in enumerate(episodes)
+                    ],
+                )
+                seasons.append(gui_season)
+
+            return seasons
+
+        except Exception:
+            logger.exception("Amazon Music get_series_metadata failed for '%s'", media_item.name)
+            return None
+
+    def start_download(self, media_item: Entries, season: Optional[str] = None, episodes: Optional[str] = None) -> bool:
+        """
+        Start a download for a selected track or album by delegating to the service.
+        """
+        search_fn = self._get_search_fn()
+
+        selections = {}
+        if season:
+            selections["season"] = season
+        if episodes:
+            selections["episode"] = episodes
+
+        # Propagate audio_format if set on the media_item (flac / mp3)
+        audio_format = getattr(media_item, "audio_format", None)
+        if audio_format:
+            selections["audio_format"] = audio_format
+
+        scrape_serie = self.get_cached_scraper(media_item)
+
+        search_fn(direct_item=media_item.raw_data, selections=selections or None, scrape_serie=scrape_serie)
+        return True

--- a/GUI/searchapp/api/crunchyroll.py
+++ b/GUI/searchapp/api/crunchyroll.py
@@ -1,145 +1,23 @@
 # 16.03.25
 
-import importlib
-from typing import List, Optional
+from typing import Any, Dict
 
-from .base import BaseStreamingAPI, Entries, Season, Episode
+from .generic import GenericStreamingAPI
+from .base import Entries
 
-from VibraVid.services._base.site_loader import get_folder_name
 from VibraVid.services.crunchyroll.scrapper import GetSerieInfo
 
 
-class CrunchyrollAPI(BaseStreamingAPI):
-    def __init__(self):
-        super().__init__()
-        self.site_name = "crunchyroll"
-        self._load_config()
-        self._search_fn = None
-        self._client = None
-    
-    def _load_config(self):
-        """Load site configuration and verify credentials."""
-        self.base_url = "https://www.crunchyroll.com"
-        
-    def _get_search_fn(self):
-        """Lazy load the search function."""
-        if self._search_fn is None:
-            module = importlib.import_module(f"VibraVid.{get_folder_name()}.{self.site_name}")
-            self._search_fn = getattr(module, "search")
-        return self._search_fn
-    
-    def search(self, query: str) -> List[Entries]:
-        """
-        Search for content on Crunchyroll.
-        
-        Args:
-            query: Search term
-            
-        Returns:
-            List of Entries objects
-        """
-        search_fn = self._get_search_fn()
-        database = search_fn(query, get_onlyDatabase=True)
-        
-        results = []
-        if database and hasattr(database, 'media_list'):
-            items = list(database.media_list)
-            for element in items:
-                item_dict = element.__dict__.copy() if hasattr(element, '__dict__') else {}
-                
-                media_item = Entries(
-                    id=item_dict.get('id'),
-                    name=item_dict.get('name'),
-                    slug=item_dict.get('id'),
-                    path_id=item_dict.get('path_id'),
-                    type=item_dict.get('type'),
-                    url=item_dict.get('url'),
-                    poster=item_dict.get('image'),
-                    year=item_dict.get('year'),
-                    tmdb_id=item_dict.get('tmdb_id'),
-                    raw_data=item_dict
-                )
-                results.append(media_item)
-        
-        return results
-    
-    def get_series_metadata(self, media_item: Entries) -> Optional[List[Season]]:
-        """
-        Get seasons and episodes for a Crunchyroll series.
-        
-        Args:
-            media_item: Entries to get metadata for
-            
-        Returns:
-            List of Season objects, or None if not a series
-        """
-        # Check if it's a movie
-        if media_item.is_movie:
-            return None
-        
-        # Extract series ID from URL
-        series_id = media_item.url.split("/")[-1]
-        
-        # Initialize scraper
-        scrape_serie = self.get_cached_scraper(media_item)
-        if not scrape_serie:
-            scrape_serie = GetSerieInfo(series_id)
-            self.set_cached_scraper(media_item, scrape_serie)
+class CrunchyrollAPI(GenericStreamingAPI):
+    site_name = "crunchyroll"
+    base_url = "https://www.crunchyroll.com"
+    log_label = "Crunchyroll"
 
-        seasons_count = scrape_serie.getNumberSeason()
-        
-        if not seasons_count:
-            print(f"[Crunchyroll] No seasons found for: {media_item.name}")
-            return None
-        
-        seasons = []
-        for s in scrape_serie.seasons_manager.seasons:
-            season_num = s.number
-            season_name = getattr(s, 'name', None)
-            
-            episodes_raw = scrape_serie.getEpisodeSeasons(s.number)
-            episodes = []
-            
-            for idx, ep in enumerate(episodes_raw or [], 1):
-                ep_number = getattr(ep, "number", None)
-                if not ep_number and ep_number != 0:
-                    ep_number = idx
-                
-                episode = Episode(
-                    number=ep_number,
-                    name=getattr(ep, 'name', f"Episode {idx}"),
-                    id=getattr(ep, 'id', idx)
-                )
-                episodes.append(episode)
-            
-            season = Season(number=season_num, episodes=episodes, name=season_name)
-            seasons.append(season)
-            print(f"[Crunchyroll] Season {season_num} ({season_name or f'Season {season_num}'}): {len(episodes)} episodes")
-        
-        return seasons if seasons else None
-    
-    def start_download(self, media_item: Entries, season: Optional[str] = None, episodes: Optional[str] = None) -> bool:
-        """
-        Start downloading from Crunchyroll.
-        
-        Args:
-            media_item: Entries to download
-            season: Season number (for series)
-            episodes: Episode selection
-            
-        Returns:
-            True if download started successfully
-        """
-        search_fn = self._get_search_fn()
-        
-        # Prepare selections
-        selections = None
-        if season or episodes:
-            selections = {
-                'season': season,
-                'episode': episodes
-            }
-        
-        scrape_serie = self.get_cached_scraper(media_item)
-        search_fn(direct_item=media_item.raw_data, selections=selections, scrape_serie=scrape_serie)
-        return True
+    def _build_entry(self, item_dict: Dict[str, Any]) -> Entries:
+        entry = super()._build_entry(item_dict)
+        entry.slug = item_dict.get('id')   # crunchyroll uses the id as slug
+        return entry
+
+    def _build_scraper(self, media_item: Entries):
+        series_id = media_item.url.split("/")[-1]
+        return GetSerieInfo(series_id)

--- a/GUI/searchapp/api/discovery.py
+++ b/GUI/searchapp/api/discovery.py
@@ -1,137 +1,15 @@
 # 08.04.26
 
-import importlib
-from typing import List, Optional
+from .generic import GenericStreamingAPI
+from .base import Entries
 
-from .base import BaseStreamingAPI, Entries, Season, Episode
-
-from VibraVid.services._base.site_loader import get_folder_name
 from VibraVid.services.realtime.scrapper import GetSerieInfo
 
 
-class DiscoveryAPI(BaseStreamingAPI):
-    def __init__(self):
-        super().__init__()
-        self.site_name = "discovery"
-        self._load_config()
-        self._search_fn = None
-    
-    def _load_config(self):
-        """Load site configuration."""
-        self.base_url = None
-    
-    def _get_search_fn(self):
-        """Lazy load the search function."""
-        if self._search_fn is None:
-            module = importlib.import_module(f"VibraVid.{get_folder_name()}.{self.site_name}")
-            self._search_fn = getattr(module, "search")
-        return self._search_fn
-    
-    def search(self, query: str) -> List[Entries]:
-        """
-        Search for content on Discovery Channel Italy.
-        
-        Args:
-            query: Search term
-            
-        Returns:
-            List of Entries objects
-        """
-        search_fn = self._get_search_fn()
-        database = search_fn(query, get_onlyDatabase=True)
-        
-        results = []
-        if database and hasattr(database, 'media_list'):
-            items = list(database.media_list)
-            for element in items:
-                item_dict = element.__dict__.copy() if hasattr(element, '__dict__') else {}
-                
-                media_item = Entries(
-                    id=item_dict.get('id'),
-                    name=item_dict.get('name'),
-                    path_id=item_dict.get('path_id'),
-                    type=item_dict.get('type'),
-                    url=item_dict.get('url'),
-                    poster=item_dict.get('image'),
-                    year=item_dict.get('year'),
-                    tmdb_id=item_dict.get('tmdb_id'),
-                    raw_data=item_dict
-                )
-                results.append(media_item)
-        
-        return results
-    
-    def get_series_metadata(self, media_item: Entries) -> Optional[List[Season]]:
-        """
-        Get seasons and episodes for a Discovery series.
-        
-        Args:
-            media_item: Entries to get metadata for
-            
-        Returns:
-            List of Season objects, or None if not a series
-        """
-        if media_item.is_movie:
-            return None
-        
-        scrape_serie = self.get_cached_scraper(media_item)
-        if not scrape_serie:
-            scrape_serie = GetSerieInfo(media_item.url)
-            self.set_cached_scraper(media_item, scrape_serie)
+class DiscoveryAPI(GenericStreamingAPI):
+    """Discovery Channel IT — uses the shared realtime scrapper."""
+    site_name = "discovery"
+    log_label = "Discovery"
 
-        seasons_count = scrape_serie.getNumberSeason()
-        
-        if not seasons_count:
-            print(f"[Discovery Channel IT] No seasons found for: {media_item.name}")
-            return None
-    
-        seasons = []
-        for s in scrape_serie.seasons_manager.seasons:
-            season_num = s.number
-            season_name = getattr(s, 'name', None)
-            
-            episodes_raw = scrape_serie.getEpisodeSeasons(s.number)
-            episodes = []
-            
-            for idx, ep in enumerate(episodes_raw or [], 1):
-                ep_number = getattr(ep, "number", None)
-                if not ep_number and ep_number != 0:
-                    ep_number = idx
-                
-                episode = Episode(
-                    number=ep_number,
-                    name=getattr(ep, 'name', f"Episodio {idx}"),
-                    id=getattr(ep, 'id', idx)
-                )
-                episodes.append(episode)
-            
-            season = Season(number=season_num, episodes=episodes, name=season_name)
-            seasons.append(season)
-            print(f"[Discovery] Season {season_num} ({season_name or f'Season {season_num}'}): {len(episodes)} episodes")
-        
-        return seasons if seasons else None
-    
-    def start_download(self, media_item: Entries, season: Optional[str] = None, episodes: Optional[str] = None) -> bool:
-        """
-        Start downloading from Discovery.
-        
-        Args:
-            media_item: Entries to download
-            season: Season number (for series)
-            episodes: Episode selection
-            
-        Returns:
-            True if download started successfully
-        """
-        search_fn = self._get_search_fn()
-        
-        selections = None
-        if season or episodes:
-            selections = {
-                'season': season,
-                'episode': episodes
-            }
-        
-        scrape_serie = self.get_cached_scraper(media_item)
-        search_fn(direct_item=media_item.raw_data, selections=selections, scrape_serie=scrape_serie)
-        return True
+    def _build_scraper(self, media_item: Entries):
+        return GetSerieInfo(media_item.url)

--- a/GUI/searchapp/api/discoveryplus.py
+++ b/GUI/searchapp/api/discoveryplus.py
@@ -1,139 +1,15 @@
 # 27-01-26
 
-import importlib
-from typing import List, Optional
+from .generic import GenericStreamingAPI
+from .base import Entries
 
-from .base import BaseStreamingAPI, Entries, Season, Episode
-
-from VibraVid.services._base.site_loader import get_folder_name
 from VibraVid.services.discoveryplus.scrapper import GetSerieInfo
 
 
-class DiscoveryPlus(BaseStreamingAPI):
-    def __init__(self):
-        super().__init__()
-        self.site_name = "discoveryplus"
-        self._load_config()
-        self._search_fn = None
-    
-    def _load_config(self):
-        """Load site configuration."""
-        self.base_url = None    # NOT NECESSARY
-    
-    def _get_search_fn(self):
-        """Lazy load the search function."""
-        if self._search_fn is None:
-            module = importlib.import_module(f"VibraVid.{get_folder_name()}.{self.site_name}")
-            self._search_fn = getattr(module, "search")
-        return self._search_fn
-    
-    def search(self, query: str) -> List[Entries]:
-        """
-        Search for content on Discovery+.
-        
-        Args:
-            query: Search term
-            
-        Returns:
-            List of Entries objects
-        """
-        search_fn = self._get_search_fn()
-        database = search_fn(query, get_onlyDatabase=True)
-        
-        results = []
-        if database and hasattr(database, 'media_list'):
-            items = list(database.media_list)
-            for element in items:
-                item_dict = element.__dict__.copy() if hasattr(element, '__dict__') else {}
-                
-                media_item = Entries(
-                    id=item_dict.get('id'),
-                    name=item_dict.get('name'),
-                    path_id=item_dict.get('path_id'),
-                    type=item_dict.get('type'),
-                    url=item_dict.get('url'),
-                    poster=item_dict.get('image'),
-                    year=item_dict.get('year'),
-                    tmdb_id=item_dict.get('tmdb_id'),
-                    raw_data=item_dict
-                )
-                results.append(media_item)
-        
-        return results
-    
-    def get_series_metadata(self, media_item: Entries) -> Optional[List[Season]]:
-        """
-        Get seasons and episodes for a Discovery+ series.
-        
-        Args:
-            media_item: Entries to get metadata for
-            
-        Returns:
-            List of Season objects, or None if not a series
-        """
-        if media_item.is_movie:
-            return None
-        
-        # Initialize scraper with show ID
-        scrape_serie = self.get_cached_scraper(media_item)
-        if not scrape_serie:
-            scrape_serie = GetSerieInfo(media_item.id)
-            self.set_cached_scraper(media_item, scrape_serie)
+class DiscoveryPlus(GenericStreamingAPI):
+    site_name = "discoveryplus"
+    log_label = "DiscoveryPlus"
 
-        seasons_count = scrape_serie.getNumberSeason()
-        
-        if not seasons_count:
-            print(f"[DiscoveryPlus] No seasons found for: {media_item.name}")
-            return None
-    
-        seasons = []
-        for s in scrape_serie.seasons_manager.seasons:
-            season_num = s.number
-            season_name = getattr(s, 'name', None)
-            
-            episodes_raw = scrape_serie.getEpisodeSeasons(s.number)
-            episodes = []
-            
-            for idx, ep in enumerate(episodes_raw or [], 1):
-                ep_number = getattr(ep, "number", None)
-                if not ep_number and ep_number != 0:
-                    ep_number = idx
-
-                episode = Episode(
-                    number=ep_number,
-                    name=getattr(ep, 'name', f"Episodio {idx}"),
-                    id=getattr(ep, 'id', idx)
-                )
-                episodes.append(episode)
-            
-            season = Season(number=season_num, episodes=episodes, name=season_name)
-            seasons.append(season)
-            print(f"[Discovery+ EU] Season {season_num} ({season_name or f'Season {season_num}'}): {len(episodes)} episodes")
-        
-        return seasons if seasons else None
-    
-    def start_download(self, media_item: Entries, season: Optional[str] = None, episodes: Optional[str] = None) -> bool:
-        """
-        Start downloading from Discovery+.
-        
-        Args:
-            media_item: Entries to download
-            season: Season number (for series)
-            episodes: Episode selection
-            
-        Returns:
-            True if download started successfully
-        """
-        search_fn = self._get_search_fn()
-        
-        # Prepare selections
-        selections = None
-        if season or episodes:
-            selections = {
-                'season': season,
-                'episode': episodes
-            }
-        
-        scrape_serie = self.get_cached_scraper(media_item)
-        search_fn(direct_item=media_item.raw_data, selections=selections, scrape_serie=scrape_serie)
-        return True
+    def _build_scraper(self, media_item: Entries):
+        # Discovery+ is keyed by the show id, not the url.
+        return GetSerieInfo(media_item.id)

--- a/GUI/searchapp/api/dmax.py
+++ b/GUI/searchapp/api/dmax.py
@@ -1,141 +1,16 @@
 # 02.02.26
 
-import importlib
-from typing import List, Optional
+from .generic import GenericStreamingAPI
+from .base import Entries
 
-from .base import BaseStreamingAPI, Entries, Season, Episode
-
-from VibraVid.services._base.site_loader import get_folder_name
 from VibraVid.services.realtime.scrapper import GetSerieInfo
 
 
-class DmaxAPI(BaseStreamingAPI):
-    def __init__(self):
-        super().__init__()
-        self.site_name = "dmax"
-        self._load_config()
-        self._search_fn = None
-    
-    def _load_config(self):
-        """Load site configuration."""
-        self.base_url = "https://public.aurora.enhanced.live"
-    
-    def _get_search_fn(self):
-        """Lazy load the search function."""
-        if self._search_fn is None:
-            module = importlib.import_module(f"VibraVid.{get_folder_name()}.{self.site_name}")
-            self._search_fn = getattr(module, "search")
-        return self._search_fn
-    
-    def search(self, query: str) -> List[Entries]:
-        """
-        Search for content on Dmax.
-        
-        Args:
-            query: Search term
-            
-        Returns:
-            List of Entries objects
-        """
-        search_fn = self._get_search_fn()
-        database = search_fn(query, get_onlyDatabase=True)
-        
-        results = []
-        if database and hasattr(database, 'media_list'):
-            items = list(database.media_list)
-            for element in items:
-                item_dict = element.__dict__.copy() if hasattr(element, '__dict__') else {}
-                
-                media_item = Entries(
-                    name=item_dict.get('name'),
-                    path_id=item_dict.get('path_id'),
-                    type=item_dict.get('type'),
-                    url=item_dict.get('url'),
-                    poster=item_dict.get('image'),
-                    year=item_dict.get('year'),
-                    tmdb_id=item_dict.get('tmdb_id'),
-                    raw_data=item_dict
-                )
-                results.append(media_item)
-        
-        return results
-    
-    def get_series_metadata(self, media_item: Entries) -> Optional[List[Season]]:
-        """
-        Get seasons and episodes for a Dmax series.
-        
-        Args:
-            media_item: Entries to get metadata for
-            
-        Returns:
-            List of Season objects, or None if not a series
-        """
-        if media_item.is_movie:
-            return None
-        
-        scrape_serie = self.get_cached_scraper(media_item)
-        if not scrape_serie:
-            scrape_serie = GetSerieInfo(media_item.url)
-            self.set_cached_scraper(media_item, scrape_serie)
+class DmaxAPI(GenericStreamingAPI):
+    """Dmax — uses the shared realtime scrapper."""
+    site_name = "dmax"
+    base_url = "https://public.aurora.enhanced.live"
+    log_label = "Dmax"
 
-        scrape_serie.getNumberSeason()
-        seasons_count = len(scrape_serie.seasons_manager)
-        
-        if not seasons_count:
-            print(f"[Dmax] No seasons found for: {media_item.name}")
-            return None
-    
-        seasons = []
-        for s in scrape_serie.seasons_manager.seasons:
-            season_num = s.number
-            season_name = getattr(s, 'name', None)
-            
-            episodes_raw = scrape_serie.getEpisodeSeasons(s.number)
-            episodes = []
-            
-            for idx, ep in enumerate(episodes_raw or [], 1):
-                ep_number = getattr(ep, "number", None)
-                if not ep_number and ep_number != 0:
-                    ep_number = idx
-
-                episode = Episode(
-                    number=ep_number,
-                    name=getattr(ep, 'name', f"Episodio {idx}"),
-                    id=getattr(ep, 'id', idx)
-                )
-                episodes.append(episode)
-            
-            season = Season(number=season_num, episodes=episodes, name=season_name)
-            seasons.append(season)
-            print(f"[DMAX] Season {season_num} ({season_name or f'Season {season_num}'}): {len(episodes)} episodes")
-        
-        return seasons if seasons else None
-    
-    def start_download(self, media_item: Entries, season: Optional[str] = None, episodes: Optional[str] = None) -> bool:
-        """
-        Start downloading from Dmax.
-        
-        Args:
-            media_item: Entries to download
-            season: Season number (for series)
-            episodes: Episode selection
-            
-        Returns:
-            True if download started successfully
-        """
-        search_fn = self._get_search_fn()
-        
-        # Prepare selections
-        selections = None
-        if season or episodes:
-            selections = {
-                'season': season,
-                'episode': episodes
-            }
-        
-        scrape_serie = self.get_cached_scraper(media_item)
-        
-        # Execute download
-        scrape_serie = self.get_cached_scraper(media_item)
-        search_fn(direct_item=media_item.raw_data, selections=selections, scrape_serie=scrape_serie)
-        return True
+    def _build_scraper(self, media_item: Entries):
+        return GetSerieInfo(media_item.url)

--- a/GUI/searchapp/api/foodnetwork.py
+++ b/GUI/searchapp/api/foodnetwork.py
@@ -1,138 +1,17 @@
 # 27.01.26
 
-import importlib
-from typing import List, Optional
+from .generic import GenericStreamingAPI
+from .base import Entries
 
-from .base import BaseStreamingAPI, Entries, Season, Episode
-
-from VibraVid.services._base.site_loader import get_folder_name
 from VibraVid.services.realtime.scrapper import GetSerieInfo
 
 
-class FoodNetworkAPI(BaseStreamingAPI):
-    def __init__(self):
-        super().__init__()
-        self.site_name = "foodnetwork"
-        self._load_config()
-        self._search_fn = None
-    
-    def _load_config(self):
-        """Load site configuration."""
-        self.base_url = "https://public.aurora.enhanced.live"
-    
-    def _get_search_fn(self):
-        """Lazy load the search function."""
-        if self._search_fn is None:
-            module = importlib.import_module(f"VibraVid.{get_folder_name()}.{self.site_name}")
-            self._search_fn = getattr(module, "search")
-        return self._search_fn
-    
-    def search(self, query: str) -> List[Entries]:
-        """
-        Search for content on Food Network.
-        
-        Args:
-            query: Search term
-            
-        Returns:
-            List of Entries objects
-        """
-        search_fn = self._get_search_fn()
-        database = search_fn(query, get_onlyDatabase=True)
-        
-        results = []
-        if database and hasattr(database, 'media_list'):
-            items = list(database.media_list)
-            for element in items:
-                item_dict = element.__dict__.copy() if hasattr(element, '__dict__') else {}
-                
-                media_item = Entries(
-                    name=item_dict.get('name'),
-                    path_id=item_dict.get('path_id'),
-                    type=item_dict.get('type', 'tv'),
-                    url=item_dict.get('url'),
-                    poster=item_dict.get('image'),
-                    year=item_dict.get('year'),
-                    tmdb_id=item_dict.get('tmdb_id'),
-                    raw_data=item_dict
-                )
-                results.append(media_item)
-        
-        return results
-    
-    def get_series_metadata(self, media_item: Entries) -> Optional[List[Season]]:
-        """
-        Get seasons and episodes for a Food Network series.
-        
-        Args:
-            media_item: Entries to get metadata for
-            
-        Returns:
-            List of Season objects, or None if not a series
-        """
-        if media_item.is_movie:
-            return None
-        
-        scrape_serie = self.get_cached_scraper(media_item)
-        if not scrape_serie:
-            scrape_serie = GetSerieInfo(media_item.url)
-            self.set_cached_scraper(media_item, scrape_serie)
+class FoodNetworkAPI(GenericStreamingAPI):
+    """Food Network — uses the shared realtime scrapper."""
+    site_name = "foodnetwork"
+    base_url = "https://public.aurora.enhanced.live"
+    entry_default_type = "tv"
+    log_label = "FoodNetwork"
 
-        scrape_serie.getNumberSeason()
-        seasons_count = len(scrape_serie.seasons_manager)
-        
-        if not seasons_count:
-            print(f"[FoodNetwork] No seasons found for: {media_item.name}")
-            return None
-    
-        seasons = []
-        for s in scrape_serie.seasons_manager.seasons:
-            season_num = s.number
-            season_name = getattr(s, 'name', None)
-            
-            episodes_raw = scrape_serie.getEpisodeSeasons(s.number)
-            episodes = []
-            
-            for idx, ep in enumerate(episodes_raw or [], 1):
-                ep_number = getattr(ep, "number", None)
-                if not ep_number and ep_number != 0:
-                    ep_number = idx
-
-                episode = Episode(
-                    number=ep_number,
-                    name=getattr(ep, 'name', f"Episodio {idx}"),
-                    id=getattr(ep, 'id', idx)
-                )
-                episodes.append(episode)
-            
-            season = Season(number=season_num, episodes=episodes, name=season_name)
-            seasons.append(season)
-            print(f"[FoodNetwork] Season {season_num} ({season_name or f'Season {season_num}'}): {len(episodes)} episodes")
-        
-        return seasons if seasons else None
-    
-    def start_download(self, media_item: Entries, season: Optional[str] = None, episodes: Optional[str] = None) -> bool:
-        """
-        Start downloading from Food Network.
-        
-        Args:
-            media_item: Entries to download
-            season: Season number (for series)
-            episodes: Episode selection
-            
-        Returns:
-            True if download started successfully
-        """
-        search_fn = self._get_search_fn()
-        
-        # Prepare selections
-        selections = None
-        if season or episodes:
-            selections = {
-                'season': season,
-                'episode': episodes
-            }
-        
-        scrape_serie = self.get_cached_scraper(media_item)
-        search_fn(direct_item=media_item.raw_data, selections=selections, scrape_serie=scrape_serie)
-        return True
+    def _build_scraper(self, media_item: Entries):
+        return GetSerieInfo(media_item.url)

--- a/GUI/searchapp/api/generic.py
+++ b/GUI/searchapp/api/generic.py
@@ -1,0 +1,132 @@
+# 11.07.26
+
+import importlib
+from typing import Any, Dict, List, Optional
+
+from .base import BaseStreamingAPI, Entries, Season, Episode
+
+from VibraVid.services._base.site_loader import get_folder_name
+
+
+class GenericStreamingAPI(BaseStreamingAPI):
+    """
+    Shared implementation for streaming services whose GUI adapter follows the common pattern:
+
+      * ``search()``              -> map the scraper's ``media_list`` to Entries
+      * ``get_series_metadata()`` -> build a scraper, walk ``seasons_manager``
+      * ``start_download()``      -> forward direct_item + selections to service
+    """
+    site_name: str = ""
+    base_url: Optional[str] = None
+    entry_default_type: Optional[str] = None   # fallback value for Entries.type
+    log_label: str = ""                        # prefix used in log lines
+
+    def __init__(self):
+        super().__init__()
+        self.site_name = type(self).site_name
+        self.base_url = type(self).base_url
+        self._search_fn = None
+
+    def _get_search_fn(self):
+        """Lazy-load the service's ``search`` entry point."""
+        if self._search_fn is None:
+            module = importlib.import_module(f"VibraVid.{get_folder_name()}.{self.site_name}")
+            self._search_fn = getattr(module, "search")
+        return self._search_fn
+
+    def _build_entry(self, item_dict: Dict[str, Any]) -> Entries:
+        """Map one raw scraper item dict to an Entries. Override to customise."""
+        return Entries(
+            id=item_dict.get('id'),
+            name=item_dict.get('name'),
+            slug=item_dict.get('slug', ''),
+            path_id=item_dict.get('path_id'),
+            type=item_dict.get('type', self.entry_default_type),
+            url=item_dict.get('url'),
+            poster=item_dict.get('image'),
+            year=item_dict.get('year'),
+            tmdb_id=item_dict.get('tmdb_id'),
+            provider_language=item_dict.get('provider_language'),
+            raw_data=item_dict,
+        )
+
+    def search(self, query: str) -> List[Entries]:
+        search_fn = self._get_search_fn()
+        database = search_fn(query, get_onlyDatabase=True)
+
+        results: List[Entries] = []
+        if database and hasattr(database, 'media_list'):
+            for element in list(database.media_list):
+                item_dict = element.__dict__.copy() if hasattr(element, '__dict__') else {}
+                results.append(self._build_entry(item_dict))
+        return results
+
+    def _build_scraper(self, media_item: Entries):
+        """Construct the site's series scraper for ``media_item``. Must override.
+        Return ``None`` to signal 'no scraper could be built' (treated as no series metadata).
+        """
+        raise NotImplementedError
+
+    def _map_episode(self, ep: Any, idx: int) -> Episode:
+        """Map one raw episode (dict or object) to an Episode.
+
+        A falsy/0 episode number falls back to the 1-based position ``idx`` (some
+        providers tag extras/clips with number 0); this matches the original
+        per-service adapters, which all used ``<number> or idx``.
+        """
+        if isinstance(ep, dict):
+            ep_number = ep.get('number') or idx
+            ep_name = ep.get('name') or f"Episodio {idx}"
+            ep_id = ep.get('id', idx)
+        else:
+            ep_number = getattr(ep, 'number', None) or idx
+            ep_name = getattr(ep, 'name', None) or f"Episodio {idx}"
+            ep_id = getattr(ep, 'id', idx)
+        return Episode(number=ep_number, name=ep_name, id=ep_id)
+
+    def get_series_metadata(self, media_item: Entries) -> Optional[List[Season]]:
+        """Fetch and return a list of Seasons for the given series media_item, or None if not applicable."""
+        if media_item.is_movie:
+            return None
+
+        scrape_serie = self.get_cached_scraper(media_item)
+        if not scrape_serie:
+            scrape_serie = self._build_scraper(media_item)
+            if scrape_serie is None:
+                return None
+            self.set_cached_scraper(media_item, scrape_serie)
+
+        scrape_serie.getNumberSeason()
+        if not len(scrape_serie.seasons_manager):
+            print(f"[{self.log_label or self.site_name}] No seasons found for: {media_item.name}")
+            return None
+
+        seasons: List[Season] = []
+        for s in scrape_serie.seasons_manager.seasons:
+            episodes_raw = scrape_serie.getEpisodeSeasons(s.number)
+            episodes = [self._map_episode(ep, i) for i, ep in enumerate(episodes_raw or [], 1)]
+            season = Season(number=s.number, episodes=episodes, name=getattr(s, 'name', None))
+            seasons.append(season)
+            print(f"[{self.log_label or self.site_name}] Season {season.number} "
+                  f"({season.name or f'Season {season.number}'}): {len(episodes)} episodes")
+
+        return seasons if seasons else None
+
+    def _make_selections(self, season: Optional[str], episodes: Optional[str]) -> Optional[Dict[str, Any]]:
+        """Build the selections dict for the service's ``search`` entry point."""
+        if season or episodes:
+            return {'season': season, 'episode': episodes}
+        return None
+
+    def start_download(self, media_item: Entries, season: Optional[str] = None, episodes: Optional[str] = None) -> bool:
+        """Start a download for a selected track, album, or series by delegating to the service's ``search`` entry point."""
+        search_fn = self._get_search_fn()
+        selections = self._make_selections(season, episodes)
+        scrape_serie = self.get_cached_scraper(media_item)
+
+        # Prefer the scraper-provided raw_data; fall back to the Entries dict so a
+        # service that never populates raw_data still gets a valid direct_item
+        # (base_search skips the interactive prompt only when direct_item is truthy).
+        direct_item = media_item.raw_data if media_item.raw_data else media_item.__dict__.copy()
+        search_fn(direct_item=direct_item, selections=selections, scrape_serie=scrape_serie)
+        return True

--- a/GUI/searchapp/api/homegardentv.py
+++ b/GUI/searchapp/api/homegardentv.py
@@ -1,138 +1,17 @@
 # 27.01.26
 
-import importlib
-from typing import List, Optional
+from .generic import GenericStreamingAPI
+from .base import Entries
 
-from .base import BaseStreamingAPI, Entries, Season, Episode
-
-from VibraVid.services._base.site_loader import get_folder_name
 from VibraVid.services.realtime.scrapper import GetSerieInfo
 
 
-class HomeGardenTVAPI(BaseStreamingAPI):
-    def __init__(self):
-        super().__init__()
-        self.site_name = "homegardentv"
-        self._load_config()
-        self._search_fn = None
-    
-    def _load_config(self):
-        """Load site configuration."""
-        self.base_url = "https://public.aurora.enhanced.live"
-    
-    def _get_search_fn(self):
-        """Lazy load the search function."""
-        if self._search_fn is None:
-            module = importlib.import_module(f"VibraVid.{get_folder_name()}.{self.site_name}")
-            self._search_fn = getattr(module, "search")
-        return self._search_fn
-    
-    def search(self, query: str) -> List[Entries]:
-        """
-        Search for content on Home & Garden TV.
-        
-        Args:
-            query: Search term
-            
-        Returns:
-            List of Entries objects
-        """
-        search_fn = self._get_search_fn()
-        database = search_fn(query, get_onlyDatabase=True)
-        
-        results = []
-        if database and hasattr(database, 'media_list'):
-            items = list(database.media_list)
-            for element in items:
-                item_dict = element.__dict__.copy() if hasattr(element, '__dict__') else {}
-                
-                media_item = Entries(
-                    name=item_dict.get('name'),
-                    path_id=item_dict.get('path_id'),
-                    type=item_dict.get('type', 'tv'),
-                    url=item_dict.get('url'),
-                    poster=item_dict.get('image'),
-                    year=item_dict.get('year'),
-                    tmdb_id=item_dict.get('tmdb_id'),
-                    raw_data=item_dict
-                )
-                results.append(media_item)
-        
-        return results
-    
-    def get_series_metadata(self, media_item: Entries) -> Optional[List[Season]]:
-        """
-        Get seasons and episodes for a Home & Garden TV series.
-        
-        Args:
-            media_item: Entries to get metadata for
-            
-        Returns:
-            List of Season objects, or None if not a series
-        """
-        if media_item.is_movie:
-            return None
-        
-        scrape_serie = self.get_cached_scraper(media_item)
-        if not scrape_serie:
-            scrape_serie = GetSerieInfo(media_item.url)
-            self.set_cached_scraper(media_item, scrape_serie)
+class HomeGardenTVAPI(GenericStreamingAPI):
+    """Home & Garden TV — uses the shared realtime scrapper."""
+    site_name = "homegardentv"
+    base_url = "https://public.aurora.enhanced.live"
+    entry_default_type = "tv"
+    log_label = "HomeGardenTV"
 
-        scrape_serie.getNumberSeason()
-        seasons_count = len(scrape_serie.seasons_manager)
-        
-        if not seasons_count:
-            print(f"[HomeGardenTV] No seasons found for: {media_item.name}")
-            return None
-    
-        seasons = []
-        for s in scrape_serie.seasons_manager.seasons:
-            season_num = s.number
-            season_name = getattr(s, 'name', None)
-            
-            episodes_raw = scrape_serie.getEpisodeSeasons(s.number)
-            episodes = []
-            
-            for idx, ep in enumerate(episodes_raw or [], 1):
-                ep_number = getattr(ep, "number", None)
-                if not ep_number and ep_number != 0:
-                    ep_number = idx
-
-                episode = Episode(
-                    number=ep_number,
-                    name=getattr(ep, 'name', f"Episodio {idx}"),
-                    id=getattr(ep, 'id', idx)
-                )
-                episodes.append(episode)
-            
-            season = Season(number=season_num, episodes=episodes, name=season_name)
-            seasons.append(season)
-            print(f"[HomeGardenTV] Season {season_num} ({season_name or f'Season {season_num}'}): {len(episodes)} episodes")
-        
-        return seasons if seasons else None
-    
-    def start_download(self, media_item: Entries, season: Optional[str] = None, episodes: Optional[str] = None) -> bool:
-        """
-        Start downloading from Home & Garden TV.
-        
-        Args:
-            media_item: Entries to download
-            season: Season number (for series)
-            episodes: Episode selection
-            
-        Returns:
-            True if download started successfully
-        """
-        search_fn = self._get_search_fn()
-        
-        # Prepare selections
-        selections = None
-        if season or episodes:
-            selections = {
-                'season': season,
-                'episode': episodes
-            }
-        
-        scrape_serie = self.get_cached_scraper(media_item)
-        search_fn(direct_item=media_item.raw_data, selections=selections, scrape_serie=scrape_serie)
-        return True
+    def _build_scraper(self, media_item: Entries):
+        return GetSerieInfo(media_item.url)

--- a/GUI/searchapp/api/mediasetinfinity.py
+++ b/GUI/searchapp/api/mediasetinfinity.py
@@ -1,141 +1,15 @@
 # 06.06.25
 
-import importlib
-from typing import List, Optional
+from .generic import GenericStreamingAPI
+from .base import Entries
 
-from .base import BaseStreamingAPI, Entries, Season, Episode
-
-from VibraVid.services._base.site_loader import get_folder_name
 from VibraVid.services.mediasetinfinity.scrapper import GetSerieInfo
 
 
-class MediasetInfinityAPI(BaseStreamingAPI):
-    def __init__(self):
-        super().__init__()
-        self.site_name = "mediasetinfinity"
-        self._load_config()
-        self._search_fn = None
-    
-    def _load_config(self):
-        """Load site configuration."""
-        self.base_url = "https://mediasetinfinity.mediaset.it"
-    
-    def _get_search_fn(self):
-        """Lazy load the search function."""
-        if self._search_fn is None:
-            module = importlib.import_module(f"VibraVid.{get_folder_name()}.{self.site_name}")
-            self._search_fn = getattr(module, "search")
-        return self._search_fn
-    
-    def search(self, query: str) -> List[Entries]:
-        """
-        Search for content on MediasetInfinity.
-        
-        Args:
-            query: Search term
-            
-        Returns:
-            List of Entries objects
-        """
-        search_fn = self._get_search_fn()
-        database = search_fn(query, get_onlyDatabase=True)
-        
-        results = []
-        if database and hasattr(database, 'media_list'):
-            items = list(database.media_list)
-            for element in items:
-                item_dict = element.__dict__.copy() if hasattr(element, '__dict__') else {}
-                
-                media_item = Entries(
-                    id=item_dict.get('id'),
-                    name=item_dict.get('name'),
-                    slug=item_dict.get('slug', ''),
-                    path_id=item_dict.get('path_id'),
-                    type=item_dict.get('type'),
-                    url=item_dict.get('url'),
-                    poster=item_dict.get('image'),
-                    year=item_dict.get('year'),
-                    tmdb_id=item_dict.get('tmdb_id'),
-                    raw_data=item_dict
-                )
-                results.append(media_item)
-        
-        return results
+class MediasetInfinityAPI(GenericStreamingAPI):
+    site_name = "mediasetinfinity"
+    base_url = "https://mediasetinfinity.mediaset.it"
+    log_label = "MediasetInfinity"
 
-    def get_series_metadata(self, media_item: Entries) -> Optional[List[Season]]:
-        """
-        Get seasons and episodes for a MediasetInfinity series.
-        
-        Args:
-            media_item: Entries to get metadata for
-            
-        Returns:
-            List of Season objects, or None if not a series
-        """
-        if media_item.is_movie:
-            return None
-        
-        # Try to get from cache first
-        scrape_serie = self.get_cached_scraper(media_item)
-        if not scrape_serie:
-            scrape_serie = GetSerieInfo(media_item.url)
-            self.set_cached_scraper(media_item, scrape_serie)
-
-        seasons_count = scrape_serie.getNumberSeason()
-        
-        if not seasons_count:
-            print(f"[MediasetInfinity] No seasons found for url: {media_item.url}")
-            return None
-    
-        seasons = []
-        for s in scrape_serie.seasons_manager.seasons:
-            season_num = s.number
-            season_name = getattr(s, 'name', None)
-            
-            episodes_raw = scrape_serie.getEpisodeSeasons(s.number)
-            episodes = []
-            
-            for idx, ep in enumerate(episodes_raw or [], 1):
-                # Handle both dict and object types returning from scrapers
-                ep_num = (ep.get('number') if isinstance(ep, dict) else getattr(ep, 'number', idx)) or idx
-                ep_name = ep.get('name') if isinstance(ep, dict) else getattr(ep, 'name', None)
-                ep_id = ep.get('id') if isinstance(ep, dict) else getattr(ep, 'id', idx)
-                
-                episode = Episode(
-                    number=ep_num,
-                    name=ep_name if ep_name else f"Episodio {idx}",
-                    id=ep_id
-                )
-                episodes.append(episode)
-            
-            season = Season(number=season_num, episodes=episodes, name=season_name)
-            seasons.append(season)
-            print(f"[MediasetInfinity] Season {season_num} ({season_name or f'Season {season_num}'}): {len(episodes)} episodes")
-        
-        return seasons if seasons else None
-
-    def start_download(self, media_item: Entries, season: Optional[str] = None, episodes: Optional[str] = None) -> bool:
-        """
-        Start downloading from MediasetInfinity.
-        
-        Args:
-            media_item: Entries to download
-            season: Season number (for series)
-            episodes: Episode selection
-            
-        Returns:
-            True if download started successfully
-        """
-        search_fn = self._get_search_fn()
-        
-        # Prepare selections
-        selections = None
-        if season or episodes:
-            selections = {
-                'season': season,
-                'episode': episodes
-            }
-        
-        scrape_serie = self.get_cached_scraper(media_item)
-        search_fn(direct_item=media_item.raw_data, selections=selections, scrape_serie=scrape_serie)
-        return True
+    def _build_scraper(self, media_item: Entries):
+        return GetSerieInfo(media_item.url)

--- a/GUI/searchapp/api/nove.py
+++ b/GUI/searchapp/api/nove.py
@@ -1,142 +1,17 @@
 # 27.01.26
 
-import importlib
-from typing import List, Optional
+from .generic import GenericStreamingAPI
+from .base import Entries
 
-from .base import BaseStreamingAPI, Entries, Season, Episode
-
-from VibraVid.services._base.site_loader import get_folder_name
 from VibraVid.services.realtime.scrapper import GetSerieInfo
 
 
-class NoveAPI(BaseStreamingAPI):
-    def __init__(self):
-        super().__init__()
-        self.site_name = "nove"
-        self._load_config()
-        self._search_fn = None
-    
-    def _load_config(self):
-        """Load site configuration."""
-        self.base_url = "https://public.aurora.enhanced.live"
-    
-    def _get_search_fn(self):
-        """Lazy load the search function."""
-        if self._search_fn is None:
-            module = importlib.import_module(f"VibraVid.{get_folder_name()}.{self.site_name}")
-            self._search_fn = getattr(module, "search")
-        return self._search_fn
-    
-    def search(self, query: str) -> List[Entries]:
-        """
-        Search for content on Nove.
-        
-        Args:
-            query: Search term
-            
-        Returns:
-            List of Entries objects
-        """
-        search_fn = self._get_search_fn()
-        database = search_fn(query, get_onlyDatabase=True)
-        
-        results = []
-        if database and hasattr(database, 'media_list'):
-            items = list(database.media_list)
-            for element in items:
-                item_dict = element.__dict__.copy() if hasattr(element, '__dict__') else {}
-                
-                media_item = Entries(
-                    id=item_dict.get('id'),
-                    name=item_dict.get('name'),
-                    slug=item_dict.get('slug', ''),
-                    path_id=item_dict.get('path_id'),
-                    type=item_dict.get('type', 'tv'),
-                    url=item_dict.get('url'),
-                    poster=item_dict.get('image'),
-                    year=item_dict.get('year'),
-                    tmdb_id=item_dict.get('tmdb_id'),
-                    raw_data=item_dict
-                )
-                results.append(media_item)
-        
-        return results
-    
-    def get_series_metadata(self, media_item: Entries) -> Optional[List[Season]]:
-        """
-        Get seasons and episodes for a Nove series.
-        
-        Args:
-            media_item: Entries to get metadata for
-            
-        Returns:
-            List of Season objects, or None if not a series
-        """
-        if media_item.is_movie:
-            return None
-        
-        # Try to get from cache first
-        scrape_serie = self.get_cached_scraper(media_item)
-        if not scrape_serie:
-            scrape_serie = GetSerieInfo(media_item.url)
-            self.set_cached_scraper(media_item, scrape_serie)
+class NoveAPI(GenericStreamingAPI):
+    """Nove — uses the shared realtime scrapper."""
+    site_name = "nove"
+    base_url = "https://public.aurora.enhanced.live"
+    entry_default_type = "tv"
+    log_label = "Nove"
 
-        scrape_serie.getNumberSeason()
-        seasons_count = len(scrape_serie.seasons_manager)
-        
-        if not seasons_count:
-            print(f"[Nove] No seasons found for: {media_item.name}")
-            return None
-    
-        seasons = []
-        for s in scrape_serie.seasons_manager.seasons:
-            season_num = s.number
-            season_name = getattr(s, 'name', None)
-            
-            episodes_raw = scrape_serie.getEpisodeSeasons(s.number)
-            episodes = []
-            
-            for idx, ep in enumerate(episodes_raw or [], 1):
-                # Handle both dict and object types
-                ep_num = (ep.get('number') if isinstance(ep, dict) else getattr(ep, 'number', idx)) or idx
-                ep_name = ep.get('name') if isinstance(ep, dict) else getattr(ep, 'name', None)
-                ep_id = ep.get('id') if isinstance(ep, dict) else getattr(ep, 'id', idx)
-
-                episode = Episode(
-                    number=ep_num,
-                    name=ep_name if ep_name else f"Episodio {idx}",
-                    id=ep_id
-                )
-                episodes.append(episode)
-            
-            season = Season(number=season_num, episodes=episodes, name=season_name)
-            seasons.append(season)
-            print(f"[Nove] Season {season_num} ({season_name or f'Season {season_num}'}): {len(episodes)} episodes")
-        
-        return seasons if seasons else None
-    
-    def start_download(self, media_item: Entries, season: Optional[str] = None, episodes: Optional[str] = None) -> bool:
-        """
-        Start downloading from Nove.
-        
-        Args:
-            media_item: Entries to download
-            season: Season number (for series)
-            episodes: Episode selection
-            
-        Returns:
-            True if download started successfully
-        """
-        search_fn = self._get_search_fn()
-        
-        # Prepare selections
-        selections = None
-        if season or episodes:
-            selections = {
-                'season': season,
-                'episode': episodes
-            }
-        
-        scrape_serie = self.get_cached_scraper(media_item)
-        search_fn(direct_item=media_item.raw_data, selections=selections, scrape_serie=scrape_serie)
-        return True
+    def _build_scraper(self, media_item: Entries):
+        return GetSerieInfo(media_item.url)

--- a/GUI/searchapp/api/primevideo.py
+++ b/GUI/searchapp/api/primevideo.py
@@ -1,0 +1,32 @@
+# 08.03.26
+
+from typing import Any, Dict
+
+from .generic import GenericStreamingAPI
+from .base import Entries, Episode
+
+from VibraVid.services.primevideo.scrapper import GetSerieInfo
+
+
+class PrimeVideoAPI(GenericStreamingAPI):
+    site_name = "primevideo"
+    base_url = "https://www.primevideo.com"
+    log_label = "PrimeVideo"
+
+    def _build_entry(self, item_dict: Dict[str, Any]) -> Entries:
+        entry = super()._build_entry(item_dict)
+        entry.id = item_dict.get('slug')   # compact_id is carried in slug
+        return entry
+
+    def _map_episode(self, ep: Any, idx: int) -> Episode:
+        # PrimeVideo episode dicts use 'episodeNumber' / 'title' keys.
+        if isinstance(ep, dict):
+            return Episode(
+                number=ep.get('episodeNumber') or idx,
+                name=ep.get('title') or f"Episodio {idx}",
+                id=ep.get('id', idx),
+            )
+        return super()._map_episode(ep, idx)
+
+    def _build_scraper(self, media_item: Entries):
+        return GetSerieInfo(url=media_item.url)

--- a/GUI/searchapp/api/raiplay.py
+++ b/GUI/searchapp/api/raiplay.py
@@ -1,147 +1,25 @@
 # 06.06.25
 
-import importlib
-from typing import List, Optional
+from .generic import GenericStreamingAPI
+from .base import Entries
 
-from .base import BaseStreamingAPI, Entries, Season, Episode
-
-from VibraVid.services._base.site_loader import get_folder_name
 from VibraVid.services.raiplay.scrapper import GetSerieInfo
 
 
-class RaiPlayAPI(BaseStreamingAPI):
-    def __init__(self):
-        super().__init__()
-        self.site_name = "raiplay"
-        self._load_config()
-        self._search_fn = None
-        self.scrape_serie = None
-    
-    def _load_config(self):
-        """Load site configuration."""
-        self.base_url = "https://www.raiplay.it"
-    
-    def _get_search_fn(self):
-        """Lazy load the search function."""
-        if self._search_fn is None:
-            module = importlib.import_module(f"VibraVid.{get_folder_name()}.{self.site_name}")
-            self._search_fn = getattr(module, "search")
-        return self._search_fn
-    
-    def search(self, query: str) -> List[Entries]:
-        """
-        Search for content on RaiPlay.
-        
-        Args:
-            query: Search term
-            
-        Returns:
-            List of Entries objects
-        """
-        search_fn = self._get_search_fn()
-        database = search_fn(query, get_onlyDatabase=True)
-        
-        results = []
-        if database and hasattr(database, 'media_list'):
-            items = list(database.media_list)
-            for element in items:
-                item_dict = element.__dict__.copy() if hasattr(element, '__dict__') else {}
-                
-                media_item = Entries(
-                    path_id=item_dict.get('path_id'),
-                    name=item_dict.get('name'),
-                    type=item_dict.get('type'),
-                    url=item_dict.get('url'),
-                    poster=item_dict.get('image'),
-                    year=item_dict.get('year'),
-                    tmdb_id=item_dict.get('tmdb_id'),
-                    raw_data=item_dict
-                )
-                results.append(media_item)
-        
-        return results
-    
-    def get_series_metadata(self, media_item: Entries) -> Optional[List[Season]]:
-        """
-        Get seasons and episodes for a RaiPlay series.
-        
-        Args:
-            media_item: Entries to get metadata for
-            
-        Returns:
-            List of Season objects, or None if not a series
-        """
-        if media_item.is_movie:
-            return None
-        
-        # Determine unique key part
+class RaiPlayAPI(GenericStreamingAPI):
+    site_name = "raiplay"
+    base_url = "https://www.raiplay.it"
+    log_label = "RaiPlay"
+
+    def _build_scraper(self, media_item: Entries):
+        # RaiPlay is keyed by a path_id; derive it from the url when absent.
         path_id = media_item.path_id
         if not path_id:
             path_id = media_item.url.replace(self.base_url, "").lstrip("/") if media_item.url else None
-
+            
         if not path_id:
             print(f"[RaiPlay] Error: Missing path_id for {media_item.name}")
             return None
-
-        scrape_serie = self.get_cached_scraper(media_item)
-        if not scrape_serie:
-            scrape_serie = GetSerieInfo(path_id)
-            scrape_serie.collect_info_title()
-            self.set_cached_scraper(media_item, scrape_serie)
         
-        seasons_count = len(scrape_serie.seasons_manager)
-        if not seasons_count:
-            print(f"[RaiPlay] No seasons found for path_id: {path_id}")
-            return None
-    
-        seasons = []
-        for s in scrape_serie.seasons_manager.seasons:
-            season_num = s.number
-            season_name = getattr(s, 'name', None)
-            
-            episodes_raw = scrape_serie.getEpisodeSeasons(season_num)
-            episodes = []
-            
-            for idx, ep in enumerate(episodes_raw or [], 1):
-                ep_number = getattr(ep, "number", None)
-                if not ep_number and ep_number != 0:
-                    ep_number = idx
-                
-                episode = Episode(
-                    number=ep_number,
-                    name=getattr(ep, 'name', f"Episodio {idx}"),
-                    id=getattr(ep, 'id', idx)
-                )
-                episodes.append(episode)
-            
-            season = Season(number=season_num, episodes=episodes, name=season_name)
-            seasons.append(season)
-            print(f"[RaiPlay] Season {season_num} ({season_name or f'Season {season_num}'}): {len(episodes)} episodes")
-        
-        return seasons if seasons else None
-
-    def start_download(self, media_item: Entries, season: Optional[str] = None, episodes: Optional[str] = None) -> bool:
-        """
-        Start downloading from RaiPlay.
-        
-        Args:
-            media_item: Entries to download
-            season: Season number (for series)
-            episodes: Episode selection
-            
-        Returns:
-            True if download started successfully
-        """
-        search_fn = self._get_search_fn()
-        
-        # Prepare selections
-        selections = None
-        if season or episodes:
-            selections = {
-                'season': season,
-                'episode': episodes
-            }
-        
-        scrape_serie = self.get_cached_scraper(media_item)
-        search_fn(direct_item=media_item.raw_data, selections=selections, scrape_serie=scrape_serie)
-        return True
+        # getNumberSeason() triggers collect_info_title() internally when needed.
+        return GetSerieInfo(path_id)

--- a/GUI/searchapp/api/realtime.py
+++ b/GUI/searchapp/api/realtime.py
@@ -1,144 +1,16 @@
 # 27-01-26
 
+from .generic import GenericStreamingAPI
+from .base import Entries
 
-import importlib
-from typing import List, Optional
-
-from .base import BaseStreamingAPI, Entries, Season, Episode
-
-from VibraVid.services._base.site_loader import get_folder_name
 from VibraVid.services.realtime.scrapper import GetSerieInfo
 
 
-class RealtimeAPI(BaseStreamingAPI):
-    def __init__(self):
-        super().__init__()
-        self.site_name = "realtime"
-        self._load_config()
-        self._search_fn = None
-        self.scrape_serie = None
-    
-    def _load_config(self):
-        """Load site configuration."""
-        self.base_url = "https://public.aurora.enhanced.live"
-    
-    def _get_search_fn(self):
-        """Lazy load the search function."""
-        if self._search_fn is None:
-            module = importlib.import_module(f"VibraVid.{get_folder_name()}.{self.site_name}")
-            self._search_fn = getattr(module, "search")
-        return self._search_fn
-    
-    def search(self, query: str) -> List[Entries]:
-        """
-        Search for content on Realtime.
-        
-        Args:
-            query: Search term
-            
-        Returns:
-            List of Entries objects
-        """
-        search_fn = self._get_search_fn()
-        database = search_fn(query, get_onlyDatabase=True)
-        
-        results = []
-        if database and hasattr(database, 'media_list'):
-            items = list(database.media_list)
-            for element in items:
-                item_dict = element.__dict__.copy() if hasattr(element, '__dict__') else {}
-                
-                media_item = Entries(
-                    id=item_dict.get('id'),
-                    name=item_dict.get('name'),
-                    slug=item_dict.get('slug', ''),
-                    path_id=item_dict.get('path_id'),
-                    type=item_dict.get('type'),
-                    url=item_dict.get('url'),
-                    poster=item_dict.get('image'),
-                    year=item_dict.get('year'),
-                    tmdb_id=item_dict.get('tmdb_id'),
-                    raw_data=item_dict
-                )
-                results.append(media_item)
-        
-        return results
-    
-    def get_series_metadata(self, media_item: Entries) -> Optional[List[Season]]:
-        """
-        Get seasons and episodes for a Realtime series.
-        
-        Args:
-            media_item: Entries to get metadata for
-            
-        Returns:
-            List of Season objects, or None if not a series
-        """
-        if media_item.is_movie:
-            return None
-        
-        # Try to get from cache first
-        scrape_serie = self.get_cached_scraper(media_item)
-        if not scrape_serie:
-            scrape_serie = GetSerieInfo(media_item.url)
-            self.set_cached_scraper(media_item, scrape_serie)
+class RealtimeAPI(GenericStreamingAPI):
+    """Realtime — uses the shared realtime scrapper."""
+    site_name = "realtime"
+    base_url = "https://public.aurora.enhanced.live"
+    log_label = "Realtime"
 
-        scrape_serie.getNumberSeason()
-        seasons_count = len(scrape_serie.seasons_manager)
-        
-        if not seasons_count:
-            print(f"[Realtime] No seasons found for: {media_item.name}")
-            return None
-    
-        seasons = []
-        for s in scrape_serie.seasons_manager.seasons:
-            season_num = s.number
-            season_name = getattr(s, 'name', None)
-            
-            episodes_raw = scrape_serie.getEpisodeSeasons(s.number)
-            episodes = []
-            
-            for idx, ep in enumerate(episodes_raw or [], 1):
-                # Handle both dict and object types
-                ep_num = (ep.get('number') if isinstance(ep, dict) else getattr(ep, 'number', idx)) or idx
-                ep_name = ep.get('name') if isinstance(ep, dict) else getattr(ep, 'name', None)
-                ep_id = ep.get('id') if isinstance(ep, dict) else getattr(ep, 'id', idx)
-
-                episode = Episode(
-                    number=ep_num,
-                    name=ep_name if ep_name else f"Episodio {idx}",
-                    id=ep_id
-                )
-                episodes.append(episode)
-            
-            season = Season(number=season_num, episodes=episodes, name=season_name)
-            seasons.append(season)
-            print(f"[Realtime] Season {season_num} ({season_name or f'Season {season_num}'}): {len(episodes)} episodes")
-        
-        return seasons if seasons else None
-
-    def start_download(self, media_item: Entries, season: Optional[str] = None, episodes: Optional[str] = None) -> bool:
-        """
-        Start downloading from Realtime.
-        
-        Args:
-            media_item: Entries to download
-            season: Season number (for series)
-            episodes: Episode selection
-            
-        Returns:
-            True if download started successfully
-        """
-        search_fn = self._get_search_fn()
-        
-        # Prepare selections
-        selections = None
-        if season or episodes:
-            selections = {
-                'season': season,
-                'episode': episodes
-            }
-        
-        scrape_serie = self.get_cached_scraper(media_item)
-        search_fn(direct_item=media_item.raw_data, selections=selections, scrape_serie=scrape_serie)
-        return True
+    def _build_scraper(self, media_item: Entries):
+        return GetSerieInfo(media_item.url)

--- a/GUI/searchapp/arr/downloader_service.py
+++ b/GUI/searchapp/arr/downloader_service.py
@@ -76,7 +76,7 @@ class ArrDownloaderService:
         logger.info(f"[_process_serie] Title='{title}', Title candidates={titles}, TMDB ID='{tmdb_id}'")
 
         year = serie.get("year")
-        year_range = self._build_year_range(year)
+        year_range = self._build_year_range(year, media_type="tv")
 
         for season in serie.get("seasons", []):
             season_num = season["number"]
@@ -903,12 +903,14 @@ class ArrDownloaderService:
         return self._unique_titles(titles)
 
     @staticmethod
-    def _build_year_range(year) -> Optional[str]:
+    def _build_year_range(year, media_type: str = "movie") -> Optional[str]:
         if not year:
             return None
         try:
             y = int(year)
             now = datetime.datetime.now().year
+            if media_type == "tv":
+                return f"{max(0, y - 1)}-{now + 1}"
             if y >= (now - 1):
                 return f"{y}-9999"
             else:

--- a/VibraVid/cli/run.py
+++ b/VibraVid/cli/run.py
@@ -175,6 +175,7 @@ def setup_argument_parser(search_functions, site_module=None, extra_site_modules
     dl_opts.add_argument('--proxy-scope', dest='proxy_scope', type=str, choices=['scrap', 'down', 'scrap+down'], metavar='scrap|down|scrap+down', help='Where to apply the proxy: scraping only, downloads only, or both')
     dl_opts.add_argument('--skip-ts', dest='skip_ts', action='store_const', const=True, default=None, help='Skip TS/CAM releases (StreamingCommunity)')
     dl_opts.add_argument('--close-console', dest='close_console', type=str, choices=['true', 'false'], metavar='true|false', help='Exit after last download (overrides config)')
+    dl_opts.add_argument('--no-vault-cache', dest='bypass_vault_cache', action='store_const', const=True, default=None, help='Bypass DRM key vault cache; force a fresh CDM license request every run (for dynamic/time-sensitive tokens)')
 
     # ── Direct download
     dl_group = parser.add_argument_group('Direct download (--down)')
@@ -513,6 +514,7 @@ def main():
         # Propagate CLI download limits to the service flow
         context_tracker.max_segments = getattr(args, 'max_segments', None)
         context_tracker.max_time = getattr(args, 'max_time', None)
+        context_tracker.bypass_vault_cache = getattr(args, 'bypass_vault_cache', None)
         site_options = {'drm': getattr(args, 'drm', None)}
         site_options.update({dest: getattr(args, dest, None) for dest in site_option_dests})
         context_tracker.site_options = site_options

--- a/VibraVid/core/decryptor/_models.py
+++ b/VibraVid/core/decryptor/_models.py
@@ -44,6 +44,7 @@ class EncryptionInfo:
     pssh_b64: Optional[str] = None                      # selected PSSH system-id (populated by _finalize)
     video_codec: Optional[str] = None                   # e.g. "H.264", "HEVC"
     encryption_method: Optional[str] = None             # e.g. "SAMPLE_AES"
+    track_ids: Optional[list[str]] = None               # list of track IDs (if available)
     pssh_boxes: list[dict] = field(default_factory=list)
 
 
@@ -86,6 +87,7 @@ def detect_encryption_info(file_path: str) -> EncryptionInfo:
     sinf_boxes = _find_all(atoms, "sinf")
     saio_boxes = _find_all(atoms, "saio")
     saiz_boxes = _find_all(atoms, "saiz")
+    trak_boxes = _find_all(atoms, "trak")
 
     for tenc in tenc_boxes:
         kid = tenc.data.get("default_KID")
@@ -111,6 +113,26 @@ def detect_encryption_info(file_path: str) -> EncryptionInfo:
         sid = pssh.data.get("system_id", b"")
         sid = sid.hex() if isinstance(sid, (bytes, bytearray)) else str(sid).replace(" ", "").lower()
         info.pssh_boxes.append({"system_id": sid, "data_size": pssh.data.get("data_size", 0)})
+
+    track_ids = []
+    for trak in trak_boxes:
+        has_enc = bool(
+            _find_all([trak], "tenc")
+            or _find_all([trak], "schm")
+            or _find_all([trak], "sinf")
+            or _find_all([trak], "saio")
+            or _find_all([trak], "saiz")
+        )
+        if not has_enc:
+            continue
+        tkhd_boxes = _find_all([trak], "tkhd")
+        if tkhd_boxes:
+            tid = tkhd_boxes[0].data.get("track_id")
+            if tid is not None:
+                track_ids.append(str(tid))
+
+    if track_ids:
+        info.track_ids = track_ids
 
     if pssh_boxes or tenc_boxes or sinf_boxes or saio_boxes or saiz_boxes:
         info.encrypted = True

--- a/VibraVid/core/drm/manager.py
+++ b/VibraVid/core/drm/manager.py
@@ -9,6 +9,7 @@ from VibraVid.utils import config_manager
 from VibraVid.utils.vault._url_utils import clean_license_url
 from VibraVid.utils.vault import supa_vault, lab_vault
 from VibraVid.core.decryptor import KeysManager
+from VibraVid.core.ui.tracker import context_tracker
 from VibraVid.setup import binary_paths
 
 from .playready import get_playready_keys
@@ -18,6 +19,7 @@ from .widevine import get_widevine_keys
 console = Console()
 logger = logging.getLogger(__name__)
 USE_CDM = config_manager.config.get_bool("DRM", "use_cdm")
+BYPASS_VAULT_CACHE = config_manager.config.get_bool("DRM", "bypass_vault_cache")
 
 
 class DRMManager:
@@ -57,6 +59,29 @@ class DRMManager:
             kid_val, key_val = k.split(":", 1)
             suffix = f" [cyan]| [#a855f7]{label}" if k in tagged else ""
             console.print(f"    - [red]{kid_val}[white]:[green]{key_val}{suffix}")
+
+    def _bypass_cache(self) -> bool:
+        """Effective bypass-vault-cache flag: per-run CLI override wins over config default."""
+        override = getattr(context_tracker, 'bypass_vault_cache', None)
+        return BYPASS_VAULT_CACHE if override is None else bool(override)
+
+    def _announce_bypass(self, all_kids: list[str], base_license_url: str, pssh_val: str, drm_type: str) -> None:
+        """When the cache is bypassed, query every configured vault only to report which cached keys would have been used, without actually using them."""
+        if not all_kids or not self._vaults:
+            return
+
+        for name, vdb in self._vaults:
+            try:
+                keys = list(vdb.get_keys_by_kids(base_license_url or None, all_kids, pssh_val) or [])
+            except Exception as e:
+                logger.debug(f"Bypass announce lookup failed for {name} vault (non-fatal): {e}")
+                continue
+
+            label = self._VAULT_LABELS.get(name, name)
+            for k in keys:
+                kid_val, _, key_val = k.partition(":")
+                logger.info(f"Bypassing cached {drm_type} key {kid_val}:{key_val} from {label} vault")
+                console.print(f"[#a855f7]Bypassing [red]{kid_val}[white]:[green]{key_val}[#a855f7] from [cyan]{label}[#a855f7] vault")
 
     def _missing_kids(self, all_kids: list[str], found_keys: list[str]) -> list[str]:
         """Return list of KIDs that are in all_kids but not yet covered by found_keys."""
@@ -149,11 +174,20 @@ class DRMManager:
             if i.get("kid") and i["kid"] != "N/A" and i.get("label")
         } or None
 
+        bypass = self._bypass_cache()
+        if bypass:
+            logger.info(f"Vault cache bypassed by config/CLI; forcing fresh CDM extraction for {drm_type}")
+            self._announce_bypass(all_kids, base_license_url, pssh_val, drm_type)
+            if not USE_CDM:
+                msg = "bypass_vault_cache is enabled but use_cdm is disabled — no keys can be produced (vault reads skipped, CDM extraction off)."
+                logger.warning(msg)
+                console.print(f"[bold yellow]WARNING: {msg}[/bold yellow]")
+
         # Step 1: vault lookup with license_url
         vault_keys: list[str] = []
         vault_source = None
 
-        if False:  # FORCED BYPASS: self._vaults and base_license_url and all_kids:
+        if self._vaults and base_license_url and all_kids and not bypass:
             found_keys, vault_source = self._db_lookup(all_kids, base_license_url, drm_type, pssh_val)
             vault_keys = list(set(found_keys))
 
@@ -166,7 +200,7 @@ class DRMManager:
                 return KeysManager(vault_keys)
 
         # Step 2: If no license_url but DRM detected → try generic lookup in database
-        if False:  # FORCED BYPASS: not license_url and all_kids and self._vaults:
+        if not license_url and all_kids and self._vaults and not bypass:
             logger.warning(f"DRM detected but missing license_url. Searching database for {len(all_kids)} {drm_type} KID(s) using 'generic' lookup")
             found_keys, vault_source = self._db_lookup(all_kids, "generic", drm_type, pssh_val)
             vault_keys = list(set(found_keys))

--- a/VibraVid/core/drm/manager.py
+++ b/VibraVid/core/drm/manager.py
@@ -153,7 +153,7 @@ class DRMManager:
         vault_keys: list[str] = []
         vault_source = None
 
-        if self._vaults and base_license_url and all_kids:
+        if False:  # FORCED BYPASS: self._vaults and base_license_url and all_kids:
             found_keys, vault_source = self._db_lookup(all_kids, base_license_url, drm_type, pssh_val)
             vault_keys = list(set(found_keys))
 
@@ -166,7 +166,7 @@ class DRMManager:
                 return KeysManager(vault_keys)
 
         # Step 2: If no license_url but DRM detected → try generic lookup in database
-        if not license_url and all_kids and self._vaults:
+        if False:  # FORCED BYPASS: not license_url and all_kids and self._vaults:
             logger.warning(f"DRM detected but missing license_url. Searching database for {len(all_kids)} {drm_type} KID(s) using 'generic' lookup")
             found_keys, vault_source = self._db_lookup(all_kids, "generic", drm_type, pssh_val)
             vault_keys = list(set(found_keys))

--- a/VibraVid/core/manifest/mpd.py
+++ b/VibraVid/core/manifest/mpd.py
@@ -333,6 +333,14 @@ class DashParser:
                     if s is None:
                         continue
 
+                    # Tag every segment with its Period so the downloader can process
+                    # multi-period tracks (distinct source files / mixed clear+encrypted
+                    # per Period) one Period at a time instead of blindly concatenating.
+                    period_encrypted = bool(s.drm and s.drm.is_encrypted())
+                    for seg in s.segments:
+                        seg.period_idx = period_idx
+                        seg.encrypted = period_encrypted
+
                     dedup_key = _stream_dedup_key(s)
 
                     if dedup_key in period_seen_keys:
@@ -347,7 +355,14 @@ class DashParser:
                         for existing_stream in streams:
                             if _stream_dedup_key(existing_stream) == dedup_key:
                                 existing_stream.segments.extend(s.segments)
+
+                                # A later Period may be encrypted while the first (e.g. a
+                                # clear intro) was not: adopt the encrypted DRM so keys are
+                                # fetched and the encrypted Period actually gets decrypted.
+                                if period_encrypted and not existing_stream.drm.is_encrypted():
+                                    existing_stream.drm = s.drm
                                 break
+
                         continue
 
                     global_seen_keys.add(dedup_key)
@@ -865,7 +880,11 @@ class DashParser:
         if init_el is not None:
             src = init_el.get("sourceURL", "")
             if src:
-                stream.add_segment(Segment(self._inherit_query(urljoin(base_url, src), self._mpd_query_suffix), 0, "init"))
+                # A sourceURL may still carry a byte range:
+                # honour it, otherwise the whole multi-rep init file is fetched and
+                # the wrong (first/lowest) moov ends up describing the track.
+                init_range = init_el.get("range", "")
+                stream.add_segment(Segment(self._inherit_query(urljoin(base_url, src), self._mpd_query_suffix), 0, "init", byte_range=init_range))
             else:
                 init_range = init_el.get("range", "")
                 if init_range:

--- a/VibraVid/core/manifest/stream.py
+++ b/VibraVid/core/manifest/stream.py
@@ -240,6 +240,8 @@ class Segment:
     byte_range: str = ""  # e.g. "12132-31195" for byte-range requests
     duration: float = 0.0          # seconds; set by parser when known (e.g. #EXTINF or <S d=…/>)
     estimated_size: int = 0        # bytes; computed from stream bitrate × duration when size == 0
+    period_idx: int = 0            # DASH Period this segment belongs to (multi-period manifests)
+    encrypted: bool = False        # True when this segment's Period is DRM-protected
 
     def get_effective_size(self) -> int:
         """Return real size if downloaded/known, otherwise the estimate."""

--- a/VibraVid/core/ui/tracker.py
+++ b/VibraVid/core/ui/tracker.py
@@ -494,6 +494,14 @@ class ContextTracker:
         self.local.max_time = value
 
     @property
+    def bypass_vault_cache(self):
+        return getattr(self.local, 'bypass_vault_cache', None)
+
+    @bypass_vault_cache.setter
+    def bypass_vault_cache(self, value):
+        self.local.bypass_vault_cache = value
+
+    @property
     def site_options(self):
         return getattr(self.local, 'site_options', None) or {}
 

--- a/VibraVid/core/velora/_ism_postproc.py
+++ b/VibraVid/core/velora/_ism_postproc.py
@@ -35,7 +35,42 @@ class IsmPostprocMixin:
         return shutil.which("mp4fragment")
 
     @staticmethod
-    def _build_ism_init(stream, kid_hex: str) -> bytes:
+    def _read_fragment_track_id(data: bytes) -> Optional[int]:
+        """Return the ``track_ID`` declared in the first fragment's moof>traf>tfhd."""
+        buf = memoryview(data)
+
+        def _iter(start: int, end: int):
+            off = start
+            while off + 8 <= end:
+                size = struct.unpack(">I", buf[off:off + 4])[0]
+                typ = bytes(buf[off + 4:off + 8])
+                hdr = 8
+                if size == 1:
+                    size = struct.unpack(">Q", buf[off + 8:off + 16])[0]
+                    hdr = 16
+                elif size == 0:
+                    size = end - off
+                if size < hdr or off + size > end:
+                    return
+                yield off, size, typ, hdr
+                off += size
+
+        for moof_off, moof_size, moof_typ, moof_hdr in _iter(0, len(data)):
+            if moof_typ != b"moof":
+                continue
+            for traf_off, traf_size, traf_typ, traf_hdr in _iter(moof_off + moof_hdr, moof_off + moof_size):
+                if traf_typ != b"traf":
+                    continue
+                for tf_off, tf_size, tf_typ, tf_hdr in _iter(traf_off + traf_hdr, traf_off + traf_size):
+                    if tf_typ != b"tfhd":
+                        continue
+                    p = tf_off + tf_hdr  # skip box header; then version/flags (4) + track_ID (4)
+                    return struct.unpack(">I", buf[p + 4:p + 8])[0]
+        
+        return None
+
+    @staticmethod
+    def _build_ism_init(stream, kid_hex: str, track_id: Optional[int] = None) -> bytes:
         """Build a valid ftyp + moov for the encrypted ISM stream."""
         media_segs = [s for s in stream.segments if s.seg_type == "media"]
         seg_count = max(len(media_segs), 1)
@@ -46,6 +81,7 @@ class IsmPostprocMixin:
             duration = 20 * ISM_TIMESCALE * seg_count
 
         codec = (stream.codecs or "").lower() or "hvc1"
+        extra = {"track_id": track_id} if track_id else {}
 
         if stream.type == "video":
             return build_ism_init_segment(
@@ -56,6 +92,7 @@ class IsmPostprocMixin:
                 kid_hex=kid_hex,
                 width=stream.width or 0,
                 height=stream.height or 0,
+                **extra,
             )
 
         if stream.type == "audio":
@@ -93,6 +130,7 @@ class IsmPostprocMixin:
                 sample_rate=sr_val,
                 channels=ch_val,
                 language=getattr(stream, "language", "und") or "und",
+                **extra,
             )
 
         raise ValueError(f"Unsupported ISM stream type: {stream.type!r}")
@@ -171,10 +209,7 @@ class IsmPostprocMixin:
             logger.error("KID mancante nello stream ISM")
             return False
 
-        # 1. Generate init segment (ftyp+moov) based on stream metadata + KID (for CENC)
-        init_data = self._build_ism_init(stream, kid_hex)
-
-        # 2. Concatenate init + media segments into a single file (in the correct order, skipping invalid segments)
+        # 1. Concatenate init + media segments into a single file (in the correct order, skipping invalid segments)
         encrypted_temp = out_path.with_suffix(".enc.mp4")
 
         try:
@@ -191,10 +226,21 @@ class IsmPostprocMixin:
                 logger.error("No valid ISM segments found for concatenation")
                 return False
 
+            # 2. Generate init (ftyp+moov) using the SAME track_ID the fragments carry (read from the first fragment) so ffmpeg can match tfhd -> trak/trex.
+            frag_track_id: Optional[int] = None
+            try:
+                frag_track_id = self._read_fragment_track_id(valid_segs[0][0].read_bytes())
+            except Exception as exc:
+                logger.debug(f"ISM: could not read fragment track_id ({exc}) — using default")
+            logger.info(f"ISM init track_id={frag_track_id if frag_track_id else 1} (from fragments)")
+            init_data = self._build_ism_init(stream, kid_hex, track_id=frag_track_id)
+
+            # 3. Write the init + normalized fragments to the temporary encrypted file
             with open(encrypted_temp, "wb") as out:
                 out.write(init_data)
                 for seg_path, _ in valid_segs:
                     out.write(self._normalize_ism_fragment_sdi(seg_path.read_bytes()))
+            
         except Exception as exc:
             logger.error(f"ISM unified file creation failed: {exc}")
             return False

--- a/VibraVid/core/velora/_multiperiod.py
+++ b/VibraVid/core/velora/_multiperiod.py
@@ -1,0 +1,212 @@
+# 11.07.26
+
+import os
+import shutil
+import subprocess
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from VibraVid.utils import config_manager
+from VibraVid.setup import get_ffmpeg_path
+from VibraVid.core.decryptor import Decryptor
+from VibraVid.core.muxing.helper.video import binary_merge_segments
+from VibraVid.core.ui.bar_manager import DownloadBarManager
+
+from .util.formatting import format_size as _fmt_size, format_speed as _fmt_speed, estimate_total_size as _estimate_total_size
+
+
+logger = logging.getLogger("manual")
+REQUEST_TIMEOUT = config_manager.config.get_int("REQUESTS", "timeout")
+
+
+def _seg_number_from_path(path: Path) -> int:
+    stem = path.stem
+    if stem.startswith("seg_"):
+        try:
+            return int(stem[4:])
+        except ValueError:
+            pass
+    return 999_999_999
+
+
+def _ffmpeg_concat(part_files: List[Path], out_path: Path) -> bool:
+    """Join already-decrypted per-Period MP4s into ``out_path`` (stream copy)."""
+    if len(part_files) == 1:
+        shutil.move(str(part_files[0]), str(out_path))
+        return True
+
+    list_path = out_path.parent / f"{out_path.stem}_concat_list.txt"
+    with open(list_path, "w", encoding="utf-8") as fh:
+        for p in part_files:
+            escaped = str(p.resolve()).replace("'", "'\\''")
+            fh.write(f"file '{escaped}'\n")
+
+    cmd = [
+        get_ffmpeg_path(), "-y",
+        "-f", "concat", "-safe", "0",
+        "-i", str(list_path),
+        "-c", "copy",
+        str(out_path),
+    ]
+    logger.info(f"[multiperiod] ffmpeg concat {len(part_files)} Period file(s) -> {out_path.name}")
+    
+    try:
+        result = subprocess.run(
+            cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True, timeout=1800,
+            creationflags=(subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0),
+        )
+    except Exception as exc:
+        logger.error(f"[multiperiod] ffmpeg concat failed to run: {exc}")
+        return False
+    finally:
+        try:
+            list_path.unlink(missing_ok=True)
+        except Exception:
+            pass
+
+    if result.returncode != 0 or not out_path.exists() or out_path.stat().st_size <= 0:
+        logger.error(f"[multiperiod] ffmpeg concat failed (rc={result.returncode}): {(result.stderr or '')[-800:]}")
+        return False
+    return True
+
+
+class MultiPeriodMixin:
+    def _download_dash_multiperiod(self, stream, bar_manager: DownloadBarManager, live_decryption: bool = False) -> None:
+        """Per-Period download → merge → decrypt → ffmpeg-concat for multi-period DASH."""
+        all_headers = self._build_headers()
+        stream_dir = self._make_stream_dir(stream, "dash")
+        task_key = self._stream_task_key(stream)
+
+        # Period appearance order (preserves manifest order).
+        ordered_periods: List[int] = []
+        for seg in stream.segments:
+            if seg.period_idx not in ordered_periods:
+                ordered_periods.append(seg.period_idx)
+
+        # One flat download list with continuous numbering, remembering each
+        # segment's Period so we can regroup after the download completes.
+        dl_segs: List[Dict[str, Any]] = []
+        next_num = 0
+        for seg in stream.segments:
+            entry: Dict[str, Any] = {
+                "url": seg.url,
+                "number": next_num,
+                "seg_type": seg.seg_type,
+                "enc": {"method": "NONE"},
+                "period_idx": seg.period_idx,
+            }
+            if seg.byte_range:
+                entry["headers"] = {"Range": f"bytes={seg.byte_range}"}
+            dl_segs.append(entry)
+            next_num += 1
+
+        self._assign_segment_durations(stream, dl_segs, all_headers)
+
+        if self.max_segments and self.max_segments > 0:
+            dl_segs = dl_segs[:self.max_segments]
+            logger.debug(f"Limiting multi-period DASH download to {len(dl_segs)} segments (max_segments={self.max_segments})")
+        dl_segs = self._apply_max_time(dl_segs)
+
+        num_to_period = {e["number"]: e["period_idx"] for e in dl_segs}
+
+        total = len(dl_segs)
+
+        def _progress(done: int, total_: int, total_bytes: int, speed_bps: float, speed_label: Optional[str] = None) -> None:
+            pct = int((done / total_) * 100) if total_ else 0
+            estimated_total = _estimate_total_size(total_bytes, done, total_) if done > 0 else total_bytes
+            size_display = (
+                f"{_fmt_size(total_bytes)}/{_fmt_size(estimated_total)}"
+                if done < total_
+                else f"{_fmt_size(total_bytes)}/{_fmt_size(total_bytes)}"
+            )
+            bar_manager.handle_progress_line({
+                "task_key": task_key,
+                "pct": pct,
+                "segments": f"{done}/{total_}",
+                "size": size_display,
+                "speed": speed_label if speed_label is not None else _fmt_speed(speed_bps),
+            })
+
+        paths = self._run_dl(dl_segs, stream_dir, all_headers, _progress, stream=stream, default_ext="mp4")
+
+        if self._stop_check() or not paths:
+            return
+
+        # Regroup downloaded files by Period.
+        period_paths: Dict[int, List[Path]] = {p: [] for p in ordered_periods}
+        for p in paths:
+            n = _seg_number_from_path(p)
+            per = num_to_period.get(n)
+            if per is not None and p.exists() and p.stat().st_size > 0:
+                period_paths.setdefault(per, []).append(p)
+
+        decryptor = Decryptor() if self.key else None
+        part_files: List[Path] = []
+
+        for order_idx, per in enumerate(ordered_periods):
+            p_paths = sorted(period_paths.get(per, []), key=_seg_number_from_path)
+            if not p_paths:
+                continue
+
+            part_merged = stream_dir / f"period_{order_idx:03d}.mp4"
+            bar_manager.handle_progress_line({"task_key": task_key, "pct": 100, "speed": f"Merge P{order_idx}"})
+            binary_merge_segments(p_paths, part_merged, merge_logger=logger)
+
+            if not part_merged.exists() or part_merged.stat().st_size <= 0:
+                logger.error(f"[multiperiod] Period {order_idx} merge produced empty file")
+                continue
+
+            # Decrypt if keys are available — Decryptor auto-detects and simply
+            # copies clear Periods (e.g. a clear intro), decrypts encrypted ones.
+            if decryptor is not None:
+                dec_path = part_merged.with_suffix(".dec.mp4")
+
+                def _dec_cb(parsed: Optional[Dict[str, Any]]) -> None:
+                    if parsed:
+                        bar_manager.handle_progress_line({
+                            "task_key": task_key,
+                            "pct": parsed.get("pct"),
+                            "speed": parsed.get("status") or f"Dec P{order_idx}",
+                        })
+
+                try:
+                    if decryptor.decrypt(str(part_merged), self.key, str(dec_path), stream_type=stream.type, progress_cb=_dec_cb) and dec_path.exists() and dec_path.stat().st_size > 0:
+                        part_merged.unlink(missing_ok=True)
+                        dec_path.rename(part_merged)
+                    else:
+                        logger.warning(f"[multiperiod] Period {order_idx} decryption failed — keeping raw merge")
+                        dec_path.unlink(missing_ok=True)
+                except Exception as exc:
+                    logger.error(f"[multiperiod] Period {order_idx} decryption error: {exc}")
+                    try:
+                        dec_path.unlink(missing_ok=True)
+                    except Exception:
+                        pass
+
+            part_files.append(part_merged)
+
+        if not part_files:
+            logger.error("[multiperiod] no Period produced a usable file")
+            return
+
+        out_path = self.output_dir / self._out_filename(stream, "mp4")
+        bar_manager.handle_progress_line({"task_key": task_key, "pct": 100, "speed": "Concat"})
+
+        if _ffmpeg_concat(part_files, out_path) and out_path.exists() and out_path.stat().st_size > 0:
+            logger.info(f"[multiperiod] {len(part_files)} Period(s) joined -> {out_path.name} ({out_path.stat().st_size // 1024} KB)")
+            bar_manager.handle_progress_line({
+                "task_key": task_key, "pct": 100,
+                "segments": f"{total}/{total}",
+                "size": f"{_fmt_size(out_path.stat().st_size)}/{_fmt_size(out_path.stat().st_size)}",
+                "speed": "Done",
+            })
+        else:
+            logger.error(f"[multiperiod] failed to assemble final file for {stream.type} {stream.resolution or stream.language}")
+
+        # Clean up per-Period intermediates.
+        for pf in part_files:
+            try:
+                pf.unlink(missing_ok=True)
+            except Exception:
+                pass

--- a/VibraVid/core/velora/_stream_vod.py
+++ b/VibraVid/core/velora/_stream_vod.py
@@ -229,6 +229,16 @@ class VodStreamMixin:
             logger.error(f"DASH stream has no segments: {stream}")
             return
 
+        # Multi-period tracks (same representation id spread across Periods that use
+        # distinct source files and/or mix clear + encrypted content) can't be
+        # concatenated into one file: each Period has its own init/moov and DRM.
+        # Hand them to the Period-aware path (merge + decrypt + concat per Period).
+        media_periods = {s.period_idx for s in stream.segments if s.seg_type == "media"}
+        if len(media_periods) > 1:
+            logger.info(f"DASH multi-period stream detected ({len(media_periods)} periods) — using per-period pipeline | {stream.type} {stream.resolution or stream.language}")
+            self._download_dash_multiperiod(stream, bar_manager, live_decryption)
+            return
+
         all_headers = self._build_headers()
         chunk_size = max(8 * 1024 * 1024, 1 * 1024 * 1024)
         media_segments = [s for s in stream.segments if s.seg_type == "media"]

--- a/VibraVid/core/velora/downloader.py
+++ b/VibraVid/core/velora/downloader.py
@@ -21,6 +21,7 @@ from VibraVid.core.decryptor._models import detect_encryption_info
 from .base import BaseMediaDownloader
 from .downloader_live import LiveDownloadMixin
 from ._stream_vod import VodStreamMixin
+from ._multiperiod import MultiPeriodMixin
 from ._decrypt_pipeline import DecryptPipelineMixin
 from ._ism_postproc import IsmPostprocMixin
 from .util._stream_helpers import detect_seg_ext, join_interruptible, print_failed_segments_report, SilentDownloadBarManager
@@ -33,9 +34,11 @@ RETRY_COUNT = config_manager.config.get_int("REQUESTS",  "max_retry")
 REQUEST_TIMEOUT = config_manager.config.get_int("REQUESTS",  "timeout")
 VERIFY_TLS = config_manager.config.get_bool("REQUESTS", "verify")
 REALTIME_DECRYPT = config_manager.config.get_bool("DOWNLOAD", "realtime_decrypt")
+SEGMENT_DELAY_SECONDS = max(0.0, config_manager.config.get_float("DOWNLOAD", "segment_delay_seconds"))
+SEGMENT_DELAY_JITTER_SECONDS = max(0.0, config_manager.config.get_float("DOWNLOAD", "segment_delay_jitter_seconds"))
 
 
-class MediaDownloader(LiveDownloadMixin, VodStreamMixin, DecryptPipelineMixin, IsmPostprocMixin, BaseMediaDownloader):
+class MediaDownloader(LiveDownloadMixin, VodStreamMixin, MultiPeriodMixin, DecryptPipelineMixin, IsmPostprocMixin, BaseMediaDownloader):
     def __init__(self, url: str, output_dir: str, filename: str, headers: Optional[Dict] = None, key: Optional[Any] = None, cookies: Optional[Dict] = None, download_id: Optional[str] = None, site_name: Optional[str] = None, max_segments: Optional[int] = None, max_time: Optional[float] = None, manifest_content: Optional[str] = None, manifest_protocol: Optional[str] = None, manifest_refresh_fn=None) -> None:
         super().__init__(
             url=url,
@@ -283,6 +286,8 @@ class MediaDownloader(LiveDownloadMixin, VodStreamMixin, DecryptPipelineMixin, I
                 "retry_base_delay_seconds": 1.0,
                 "retry_max_delay_seconds": 4.0,
                 "retry_jitter_seconds": 0.25,
+                "segment_delay_seconds": SEGMENT_DELAY_SECONDS,
+                "segment_delay_jitter_seconds": SEGMENT_DELAY_JITTER_SECONDS,
                 "proxy_url": get_proxy_url(),
                 "verify_tls": VERIFY_TLS,
                 "headers": headers,
@@ -333,7 +338,8 @@ class MediaDownloader(LiveDownloadMixin, VodStreamMixin, DecryptPipelineMixin, I
         # every DRM system (Widevine/PlayReady/FairPlay) protecting it.
         kid = info.kid or "N/A"
         scheme = info.scheme or "unknown"
-        logger.info(f"[PROBE][{target_path.name}] Scheme: {scheme}, KID: {kid}")
+        track_ids = info.track_ids or []
+        logger.info(f"[PROBE][{target_path.name}] Scheme: {scheme}, KID: {kid}, Track IDs: {track_ids}")
 
     def _build_headers(self) -> Dict:
         h = dict(self.headers)


### PR DESCRIPTION
Explain that under certain streaming conditions (like dynamic or time-sensitive tokens on live/coaching platforms), the manager reuses old Key IDs from the vault cache instead of hitting the license server, causing authentication errors. Mention that forcing the bypass ensures a fresh CDM extraction request every time.