### PR TITLE
[Fix] Add atomic segment/merge writing and deep segment validation on resume

### DIFF
--- a/VibraVid/core/downloader/base.py
+++ b/VibraVid/core/downloader/base.py
@@ -456,6 +456,13 @@ class BaseDownloader:
         )
         self.last_merge_result = result_json
         if not self._merge_output_ok(merged_file):
+            logger.error(f"Merge failed for {self.filename_base}. Cleaning up corrupted intermediate merged files in {self.output_dir}.")
+            try:
+                for item in Path(self.output_dir).glob("*.*"):
+                    if item.is_file() and item.suffix.lower() in (".ts", ".m4a", ".mp4", ".mkv", ".tmp", ".vtt", ".srt"):
+                        item.unlink(missing_ok=True)
+            except Exception as e:
+                logger.warning(f"Failed to clean up intermediate files: {e}")
             return None
         # Chapters are already baked into merged_file by join_media() above — no separate _inject_chapters() pass needed.
         return self._embed_poster(merged_file)

--- a/VibraVid/core/downloader/dash.py
+++ b/VibraVid/core/downloader/dash.py
@@ -802,10 +802,17 @@ class DASH_Downloader(BaseDownloader):
         self.media_downloader.set_key(self.decryption_keys)
         status = self.media_downloader.start_download()
 
-        if status.get("error") == "cancelled":
+        if status.get("error"):
+            err = status.get("error")
+            if err == "cancelled":
+                if self.download_id:
+                    download_tracker.complete_download(self.download_id, success=False, error="cancelled")
+                return None, True, "cancelled"
+            console.print(f"[red]Error: {err}. Skipping merge of incomplete media.")
+            logger.error(f"Download incomplete: {err}")
             if self.download_id:
-                download_tracker.complete_download(self.download_id, success=False, error="cancelled")
-            return None, True, "cancelled"
+                download_tracker.complete_download(self.download_id, success=False, error=err)
+            return None, True, err
 
         if self._no_media_downloaded(status):
             logger.error("No media downloaded")

--- a/VibraVid/core/downloader/hls.py
+++ b/VibraVid/core/downloader/hls.py
@@ -475,10 +475,17 @@ class HLS_Downloader(BaseDownloader):
 
         status = self.media_downloader.start_download()
 
-        if status.get("error") == "cancelled":
+        if status.get("error"):
+            err = status.get("error")
+            if err == "cancelled":
+                if self.download_id:
+                    download_tracker.complete_download(self.download_id, success=False, error="cancelled")
+                return None, True, "cancelled"
+            console.print(f"[red]Error: {err}. Skipping merge of incomplete media.")
+            logger.error(f"Download incomplete: {err}")
             if self.download_id:
-                download_tracker.complete_download(self.download_id, success=False, error="cancelled")
-            return None, True, "cancelled"
+                download_tracker.complete_download(self.download_id, success=False, error=err)
+            return None, True, err
 
         if self._no_media_downloaded(status):
             logger.error("No media downloaded")

--- a/VibraVid/core/muxing/helper/video/merge.py
+++ b/VibraVid/core/muxing/helper/video/merge.py
@@ -62,55 +62,73 @@ def binary_merge_segments(paths: list[Path], output_path: Path, merge_logger: lo
         return
 
     total_written = 0
-    with open(output_path, "wb") as out_f:
-        png_wrapped = 0
-        for seg_path, _, seg_size in valid:
-            with open(seg_path, "rb") as in_f:
-                head = in_f.read(8)
+    tmp_output = output_path.with_suffix(output_path.suffix + ".tmp")
+    try:
+        with open(tmp_output, "wb") as out_f:
+            png_wrapped = 0
+            for seg_path, _, seg_size in valid:
+                with open(seg_path, "rb") as in_f:
+                    head = in_f.read(8)
 
-                # gzip-compressed segment (magic bytes 1f 8b): the whole segment must be held in memory to decompress it.
-                if head[:2] == b"\x1f\x8b":
-                    try:
-                        log.info(f"[binary_merge] detected gzip-compressed segment: {seg_path.name}, decompressing ...")
-                        data = gzip.decompress(head + in_f.read())
-                        out_f.write(data)
-                        total_written += len(data)
-                        continue
-                    except Exception as e:
-                        log.warning(f"[binary_merge] failed to decompress {seg_path.name}: {e}, using raw data")
-                        in_f.seek(0)
+                    # gzip-compressed segment (magic bytes 1f 8b): the whole segment must be held in memory to decompress it.
+                    if head[:2] == b"\x1f\x8b":
+                        try:
+                            log.info(f"[binary_merge] detected gzip-compressed segment: {seg_path.name}, decompressing ...")
+                            data = gzip.decompress(head + in_f.read())
+                            out_f.write(data)
+                            total_written += len(data)
+                            continue
+                        except Exception as e:
+                            log.warning(f"[binary_merge] failed to decompress {seg_path.name}: {e}, using raw data")
+                            in_f.seek(0)
+                            shutil.copyfileobj(in_f, out_f, _COPY_BUFSIZE)
+                            total_written += seg_size
+                            continue
+
+                    # PNG-wrapped segment: a fake image cover hides the real MPEG-TS payload.
+                    if head == _PNG_SIGNATURE:
+                        prefix = head + in_f.read(_PNG_SCAN_WINDOW - len(head))
+                        ts_off = _find_ts_start(prefix)
+                        if ts_off > 0:
+                            png_wrapped += 1
+                            out_f.write(prefix[ts_off:])
+                            shutil.copyfileobj(in_f, out_f, _COPY_BUFSIZE)
+
+                            # Written = (prefix after the wrapper) + (streamed tail past the scan window).
+                            total_written += (len(prefix) - ts_off) + (seg_size - len(prefix))
+                            continue
+
+                        log.warning(f"[binary_merge] PNG-wrapped segment {seg_path.name} has no TS sync, using raw data")
+                        out_f.write(prefix)
                         shutil.copyfileobj(in_f, out_f, _COPY_BUFSIZE)
                         total_written += seg_size
                         continue
 
-                # PNG-wrapped segment: a fake image cover hides the real MPEG-TS payload.
-                if head == _PNG_SIGNATURE:
-                    prefix = head + in_f.read(_PNG_SCAN_WINDOW - len(head))
-                    ts_off = _find_ts_start(prefix)
-                    if ts_off > 0:
-                        png_wrapped += 1
-                        out_f.write(prefix[ts_off:])
-                        shutil.copyfileobj(in_f, out_f, _COPY_BUFSIZE)
-
-                        # Written = (prefix after the wrapper) + (streamed tail past the scan window).
-                        total_written += (len(prefix) - ts_off) + (seg_size - len(prefix))
-                        continue
-
-                    log.warning(f"[binary_merge] PNG-wrapped segment {seg_path.name} has no TS sync, using raw data")
-                    out_f.write(prefix)
+                    # Raw segment: stream in fixed-size blocks instead of loading it whole.
+                    out_f.write(head)
                     shutil.copyfileobj(in_f, out_f, _COPY_BUFSIZE)
                     total_written += seg_size
-                    continue
 
-                # Raw segment: stream in fixed-size blocks instead of loading it whole.
-                out_f.write(head)
-                shutil.copyfileobj(in_f, out_f, _COPY_BUFSIZE)
-                total_written += seg_size
+        if tmp_output.exists() and tmp_output.stat().st_size > 0:
+            tmp_output.replace(output_path)
+        else:
+            try:
+                tmp_output.unlink(missing_ok=True)
+            except Exception:
+                pass
 
-    if png_wrapped:
-        log.info(f"[binary_merge] stripped PNG wrapper from {png_wrapped}/{len(valid)} segment(s)")
+        if png_wrapped:
+            log.info(f"[binary_merge] stripped PNG wrapper from {png_wrapped}/{len(valid)} segment(s)")
 
-    if output_path.exists() and output_path.stat().st_size > 0:
-        log.debug(f"[binary_merge] raw concat OK: {output_path.name} ({_merge_fmt_size(total_written)})")
-    else:
-        log.error(f"[binary_merge] output is empty or missing: {output_path}")
+        if output_path.exists() and output_path.stat().st_size > 0:
+            log.debug(f"[binary_merge] raw concat OK: {output_path.name} ({_merge_fmt_size(total_written)})")
+        else:
+            log.error(f"[binary_merge] output is empty or missing: {output_path}")
+
+    except Exception as exc:
+        log.error(f"[binary_merge] exception during merge: {exc}")
+        try:
+            tmp_output.unlink(missing_ok=True)
+        except Exception:
+            pass
+        raise

--- a/VibraVid/core/velora/_decrypt_pipeline.py
+++ b/VibraVid/core/velora/_decrypt_pipeline.py
@@ -20,7 +20,13 @@ from VibraVid.utils import config_manager
 from VibraVid.utils.http_client import create_client
 
 from ..decryptor._segment_crypto import decrypt_aes128
-from .util._stream_helpers import collect_failed_segments, describe_key_for_log, detect_seg_ext, merged_segment_ext
+from .util._stream_helpers import (
+    collect_failed_segments,
+    describe_key_for_log,
+    detect_seg_ext,
+    merged_segment_ext,
+    validate_segment_file,
+)
 from .util._subtitle_segments import merge_vtt_files
 from .util._verify import verify_decrypted_media
 from .util.formatting import (
@@ -108,6 +114,20 @@ class DecryptPipelineMixin:
         stream_dir = self._make_stream_dir(stream, protocol)
         all_headers = self._build_headers()
         protocol_lower = protocol.lower()
+
+        # Clean up leftover .tmp files from interrupted runs and validate existing segments
+        for tmp_file in stream_dir.glob("*.tmp"):
+            try:
+                tmp_file.unlink(missing_ok=True)
+            except Exception:
+                pass
+        for seg_file in stream_dir.glob("seg_*.*"):
+            if seg_file.suffix.lower() != ".tmp" and not validate_segment_file(seg_file):
+                logger.warning(f"Found invalid/corrupt segment from previous run ({seg_file.name}), removing for re-download")
+                try:
+                    seg_file.unlink(missing_ok=True)
+                except Exception:
+                    pass
 
         key_cache: dict[str, bytes] = {}
         segment_meta_by_path = {}

--- a/VibraVid/core/velora/curl_bridge.py
+++ b/VibraVid/core/velora/curl_bridge.py
@@ -50,6 +50,7 @@ def _fetch_one(task: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
 
     client = _get_thread_client(timeout=timeout, verify=verify, proxy_url=proxy_url)
 
+    tmp_path = Path(f"{path}.tmp")
     last_error: str | None = None
     for attempt in range(retry_count + 1):
         written = 0
@@ -60,7 +61,7 @@ def _fetch_one(task: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
                 try:
                     response.raise_for_status()
                     expected_length = response.headers.get("content-length")
-                    with open(path, "wb") as f:
+                    with open(tmp_path, "wb") as f:
                         for chunk in response.iter_content(chunk_size=65536):
                             if not chunk:
                                 continue
@@ -72,6 +73,7 @@ def _fetch_one(task: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
             if not written or (expected_length is not None and written != int(expected_length)):
                 raise ValueError(f"Incomplete/empty response body (got {written} bytes, expected {expected_length})")
 
+            tmp_path.replace(Path(path))
             return {
                 "event": "completed",
                 "task_key": task.get("task_key"),
@@ -84,6 +86,10 @@ def _fetch_one(task: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
             }
         except Exception as exc:
             last_error = str(exc)
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except Exception:
+                pass
             if attempt < retry_count:
                 delay = min(base_delay * (attempt + 1), max_delay) + random.uniform(0, jitter)
                 time.sleep(delay)

--- a/VibraVid/core/velora/downloader.py
+++ b/VibraVid/core/velora/downloader.py
@@ -256,6 +256,9 @@ class MediaDownloader(
 
         self.status = self._build_status(ext_subs, ext_auds)
 
+        if self.missing_segments_count > 0:
+            self.status["error"] = f"{self.missing_segments_count} segment(s) missing"
+
         # A stop (Ctrl+C or a tracker-level request, e.g. a live source going
         # offline) can still have produced a fully merged file by the time we
         # get here — only treat it as a cancellation if nothing was produced.

--- a/VibraVid/core/velora/util/_stream_helpers.py
+++ b/VibraVid/core/velora/util/_stream_helpers.py
@@ -127,14 +127,71 @@ def join_interruptible(
             t.join(timeout=poll)
 
 
+def validate_segment_file(path: Path) -> bool:
+    """
+    Validate a segment file on disk. Returns False if the file is missing,
+    empty, or corrupted/truncated (e.g. cut off mid-download during an interrupted run).
+    """
+    try:
+        p = Path(path)
+        if not p.exists():
+            return False
+        size = p.stat().st_size
+        if size <= 0:
+            return False
+
+        ext = p.suffix.lower().lstrip(".")
+
+        # MPEG-TS segments
+        if ext in ("ts", "m2ts"):
+            if size < 188:
+                return False
+            with open(p, "rb") as f:
+                head = f.read(188)
+                if head.startswith(b"\x89PNG\r\n\x1a\n"):
+                    return True  # PNG wrapper
+                if head.startswith(b"\x1f\x8b"):
+                    return True  # Gzip compressed
+                if head[0] != 0x47:
+                    return False
+                rem = size % 188
+                if 0 < rem < 188 and (size % 192) != 0:
+                    logger.warning(f"Segment file {p.name} is truncated ({size} bytes). Invalidating for re-download.")
+                    return False
+
+        # fMP4 / MP4 / M4S segments
+        elif ext in ("mp4", "m4s", "m4a", "m4v", "cmfv", "cmfa"):
+            if size < 8:
+                return False
+            with open(p, "rb") as f:
+                head = f.read(8)
+                box_type = head[4:8]
+                valid_boxes = (b"ftyp", b"styp", b"moof", b"mdat", b"sidx", b"emsg", b"free", b"skip", b"moov")
+                if box_type not in valid_boxes:
+                    return False
+
+        return True
+    except Exception as exc:
+        logger.debug(f"validate_segment_file exception for {path}: {exc}")
+        return False
+
+
 def collect_failed_segments(dl_segs: list, downloaded_paths: list, stream_dir, default_ext: str) -> list:
     """
     Return a list of (seg_number, url) tuples for segments that were not
-    successfully downloaded (missing file or zero-byte file).
+    successfully downloaded (missing file, zero-byte file, or corrupted/truncated file).
     """
-    downloaded_set = {
-        str(p.resolve()).casefold() for p in (downloaded_paths or []) if p.exists() and p.stat().st_size > 0
-    }
+    downloaded_set = set()
+    for p in downloaded_paths or []:
+        if p and p.exists():
+            if validate_segment_file(p):
+                downloaded_set.add(str(p.resolve()).casefold())
+            else:
+                logger.warning(f"Removing invalid/corrupted segment from disk: {p.name}")
+                try:
+                    p.unlink(missing_ok=True)
+                except Exception:
+                    pass
 
     failed = []
     for seg in dl_segs:
@@ -143,6 +200,13 @@ def collect_failed_segments(dl_segs: list, downloaded_paths: list, stream_dir, d
             seg_ext = "mp4"
 
         expected_path = Path(stream_dir) / f"seg_{seg['number']:05d}.{seg_ext}"
+        if expected_path.exists() and not validate_segment_file(expected_path):
+            logger.warning(f"Removing invalid/corrupted expected segment from disk: {expected_path.name}")
+            try:
+                expected_path.unlink(missing_ok=True)
+            except Exception:
+                pass
+
         key = str(expected_path.resolve()).casefold()
         if key not in downloaded_set:
             failed.append((seg["number"], seg.get("url", "N/A")))


### PR DESCRIPTION
### Description
Fixes an issue where interrupted media downloads leave truncated segment files (missing fMP4 `moov` atom or broken MPEG-TS packet sync) on disk. On subsequent retries, the downloader previously trusted any file with `size > 0`, skipping re-download and merging corrupted segments into broken track files that failed during `ffprobe` / `join_media()` with errors like:

```text
ffprobe error while extracting metadata: Invalid data found when processing input
[normalize] timestamp normalization failed: moov atom not found
```

### Key Changes
1. **Deep Segment Validation (`validate_segment_file`)**: Inspects MPEG-TS sync bytes (`0x47`) and packet sizes (188 bytes) as well as fMP4 box headers (`ftyp`, `styp`, `moof`, `mdat`). Purges corrupted/truncated segments automatically.
2. **Atomic Segment Downloads (`curl_bridge`)**: Streams chunks to `.tmp` files and renames only upon 100% complete download and validation.
3. **Atomic Binary Merging (`merge.py`)**: Streams concatenated output to `output_path.tmp` and replaces `output_path` atomically.
4. **Intermediate Cleanup (`base.py`)**: Purges corrupted concatenated track files if `join_media()` fails so retries are never stuck in a loop.