### PR TITLE
[Watchlist] Ripristina il toggle auto-download nella UI cinema

### DIFF
--- a/GUI/searchapp/templates/searchapp/cinema_watchlist.html
+++ b/GUI/searchapp/templates/searchapp/cinema_watchlist.html
@@ -74,20 +74,17 @@
 
 					{% if not item.is_movie %}
 						<form action="{% url 'update_watchlist_auto' item.id %}" method="post"
-						      class="cn-row js-auto-watchlist" style="gap:8px;flex:0 0 auto">
+						      class="js-auto-watchlist" style="flex:0 0 auto">
 							{% csrf_token %}
-							<label class="cn-check" style="font-size:12px" title="Download new episodes of the selected season automatically">
-								<input type="checkbox" name="auto_enabled"
-								       {% if item.auto %}checked{% endif %}
-								       {% if not item.season_numbers %}disabled{% endif %}>
-								<span>Auto</span>
-							</label>
-							<select name="auto_season" class="cn-mini" style="padding:6px 10px;flex:0 0 auto"
+							<input type="hidden" name="auto_enabled" value="on" class="js-auto-flag"
+							       {% if not item.auto %}disabled{% endif %}>
+							<select name="auto_season" class="cn-mini js-auto-season"
+							        style="padding:6px 10px;flex:0 0 auto" title="Auto-download this season's new episodes"
 							        {% if not item.season_numbers %}disabled{% endif %}>
-								<option value="">Season…</option>
+								<option value="">Not automatic</option>
 								{% for season in item.season_numbers %}
 									<option value="{{ season }}" {% if item.auto_season == season %}selected{% endif %}>
-										S{{ season }}
+										Auto · S{{ season }}
 									</option>
 								{% endfor %}
 							</select>
@@ -112,13 +109,14 @@
 
 {% block scripts %}
 <script>
-	// Auto-submit the per-item auto-download form as soon as the toggle or the season changes,
-	// so enabling auto-download never needs a separate "save" step.
+	// Single control: picking a season enables auto-download for it in one step;
+	// picking "Not automatic" disables it. No separate toggle to fight with the select.
 	document.querySelectorAll('.js-auto-watchlist').forEach(function (form) {
-		form.querySelectorAll('input, select').forEach(function (el) {
-			el.addEventListener('change', function () {
-				if (form.requestSubmit) form.requestSubmit(); else form.submit();
-			});
+		var select = form.querySelector('.js-auto-season');
+		var flag = form.querySelector('.js-auto-flag');
+		select.addEventListener('change', function () {
+			flag.disabled = !select.value;
+			if (form.requestSubmit) form.requestSubmit(); else form.submit();
 		});
 	});
 </script>

--- a/GUI/searchapp/templates/searchapp/cinema_watchlist.html
+++ b/GUI/searchapp/templates/searchapp/cinema_watchlist.html
@@ -72,6 +72,28 @@
 						<span class="cn-st is-wait">Up to date</span>
 					{% endif %}
 
+					{% if not item.is_movie %}
+						<form action="{% url 'update_watchlist_auto' item.id %}" method="post"
+						      class="cn-row js-auto-watchlist" style="gap:8px;flex:0 0 auto">
+							{% csrf_token %}
+							<label class="cn-check" style="font-size:12px" title="Download new episodes of the selected season automatically">
+								<input type="checkbox" name="auto_enabled"
+								       {% if item.auto %}checked{% endif %}
+								       {% if not item.season_numbers %}disabled{% endif %}>
+								<span>Auto</span>
+							</label>
+							<select name="auto_season" class="cn-mini" style="padding:6px 10px;flex:0 0 auto"
+							        {% if not item.season_numbers %}disabled{% endif %}>
+								<option value="">Season…</option>
+								{% for season in item.season_numbers %}
+									<option value="{{ season }}" {% if item.auto_season == season %}selected{% endif %}>
+										S{{ season }}
+									</option>
+								{% endfor %}
+							</select>
+						</form>
+					{% endif %}
+
 					<form action="{% url 'remove_from_watchlist' item.id %}" method="post" style="display:inline">
 						{% csrf_token %}
 						<button class="cn-cta is-ghost" type="submit"
@@ -86,4 +108,18 @@
 		</p>
 	{% endif %}
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+	// Auto-submit the per-item auto-download form as soon as the toggle or the season changes,
+	// so enabling auto-download never needs a separate "save" step.
+	document.querySelectorAll('.js-auto-watchlist').forEach(function (form) {
+		form.querySelectorAll('input, select').forEach(function (el) {
+			el.addEventListener('change', function () {
+				if (form.requestSubmit) form.requestSubmit(); else form.submit();
+			});
+		});
+	});
+</script>
 {% endblock %}

--- a/GUI/searchapp/views/cinema.py
+++ b/GUI/searchapp/views/cinema.py
@@ -43,7 +43,9 @@ def _watchlist_tiles(limit: int | None = None) -> list[dict]:
                 "is_new": item.has_new_episodes or item.has_new_seasons,
                 "is_movie": item.is_movie,
                 "seasons": item.num_seasons,
+                "season_numbers": list(range(1, item.num_seasons + 1)),
                 "auto": item.auto_enabled,
+                "auto_season": item.auto_season,
                 "last_checked": item.auto_last_checked_at or item.last_checked_at,
                 "p1": p1, "p2": p2,
             })


### PR DESCRIPTION
## Problema

Nel redesign "cinema" della watchlist (1.3.7, commit 2e6e4be) il template `watchlist.html` è stato sostituito da `cinema_watchlist.html`, ma i controlli per attivare l'auto-download per singola serie (switch + selezione stagione) non sono stati portati nel nuovo template. È rimasto solo un badge di sola lettura ("Automatic") e il pulsante globale "Check now".

Il backend non è mai stato toccato: la view `update_watchlist_auto`, l'endpoint `watchlist/auto/<id>/`, i campi `WatchlistItem.auto_enabled`/`auto_season` e il loop `WatchlistAuto` funzionano perfettamente — semplicemente da 1.3.7 in poi non c'è più alcun modo, dalla UI, di attivare l'auto-download su una serie. Chi aggiorna un'installazione da prima di 1.3.7 si ritrova con l'auto-download silenziosamente irraggiungibile.

## Fix

- `_watchlist_tiles()` (in `views/cinema.py`) espone anche `season_numbers` (calcolato da `num_seasons`, stesso approccio della vecchia view) e `auto_season`.
- `cinema_watchlist.html` torna ad avere, per ogni serie (non film), un controllo per attivare l'auto-download.

**Nota sul design del controllo:** il primo tentativo replicava il vecchio pattern checkbox + `<select>` separati, ma si è rivelato scomodo in test manuale — spuntare la checkbox invia subito il form (via `change`) prima ancora di scegliere la stagione, il salvataggio fallisce lato server ("seleziona una stagione") e la checkbox torna visibilmente non spuntata al reload. Ho quindi accorpato tutto in un **singolo `<select>`**: "Not automatic" oppure "Auto · S`<n>`". Scegliere una stagione invia `auto_enabled=on` + `auto_season=<n>` insieme in un solo passaggio (un input hidden viene abilitato via JS appena prima del submit); scegliere "Not automatic" invia il form con l'hidden lasciato disabilitato, quindi `auto_enabled` non viene inviato e l'item si disattiva — stesso contratto col backend, un solo click in entrambe le direzioni invece di due.

Stile riusa le classi già esistenti nel tema cinema (`.cn-mini`). Nessuna modifica ai modelli, alle migrazioni o alla logica di `watchlist_auto.py`.

## Test

Verificato manualmente su un'istanza 1.4.0 (containerizzata): aggiunta una serie di test alla watchlist, confermato via richieste HTTP dirette e shell Django che selezionare una stagione salva `auto_enabled=True`/`auto_season=<n>` in un solo submit, e che tornare su "Not automatic" li resetta a `False`/`None` in un solo submit.