### PR TITLE
[Settings] I formati di output restano "vecchi" dopo il salvataggio finché non si riavvia

### DIFF
--- a/GUI/searchapp/views/settings_view.py
+++ b/GUI/searchapp/views/settings_view.py
@@ -11,6 +11,7 @@ import zipfile
 from django.http import HttpRequest, JsonResponse
 from django.views.decorators.http import require_http_methods
 
+from VibraVid.services._base.tv_display_manager import refresh_output_formats
 from VibraVid.utils import config_manager
 
 from .._download_infra import set_max_download_slots
@@ -255,9 +256,10 @@ def save_settings(request: HttpRequest) -> JsonResponse:
 
             try:
                 config_manager.reload_config_only()
+                refresh_output_formats()
             except Exception as exc:
                 logger.exception("Failed to reload config cache after save: %s", exc)
-        
+
         elif file_type == 'login':
             try:
                 config_manager.reload_login_only()

--- a/VibraVid/services/_base/tv_display_manager.py
+++ b/VibraVid/services/_base/tv_display_manager.py
@@ -17,6 +17,26 @@ logger = logging.getLogger(__name__)
 MOVIE_FORMAT = config_manager.config.get("OUTPUT", "movie_format")
 EPISODE_FORMAT = config_manager.config.get("OUTPUT", "episode_format")
 SONG_FORMAT = config_manager.config.get("OUTPUT", "song_format", default=None)
+
+
+def refresh_output_formats() -> None:
+    """Re-read MOVIE_FORMAT/EPISODE_FORMAT/SONG_FORMAT from config.
+
+    These are cached as module-level constants (read once at import time)
+    for CLI runs, where the process is short-lived and this is harmless.
+    In the long-running GUI/Docker server, saving a new format from
+    Settings calls config_manager.reload_config_only() - which refreshes
+    the config cache itself, but does nothing for names that already
+    copied a value out of it at import time. Without this, an edited
+    output format silently keeps using whatever was in effect when the
+    server started, until the next full restart.
+    """
+    global MOVIE_FORMAT, EPISODE_FORMAT, SONG_FORMAT
+    MOVIE_FORMAT = config_manager.config.get("OUTPUT", "movie_format")
+    EPISODE_FORMAT = config_manager.config.get("OUTPUT", "episode_format")
+    SONG_FORMAT = config_manager.config.get("OUTPUT", "song_format", default=None)
+
+
 _MEDIA_TOKENS = {"quality", "language", "video_codec", "audio_codec"}
 _TMDB_TOKENS = (
     "%(tmdb_id)",


### PR DESCRIPTION
## Problema

`MOVIE_FORMAT`, `EPISODE_FORMAT` e `SONG_FORMAT` in `tv_display_manager.py` vengono letti da config **una sola volta all'import del modulo**, come costanti a livello di modulo. Per un'esecuzione CLI (processo breve, un avvio per comando) questo è innocuo. Ma la GUI/Docker è un unico processo Django a lunga vita (`manage.py runserver --noreload`): salvare un nuovo `episode_format` (o `movie_format`/`song_format`) da Settings chiama `config_manager.reload_config_only()`, che ricarica correttamente la cache generale di configurazione, ma non tocca in alcun modo queste tre costanti — restano silenziosamente ancorate al valore che era attivo all'avvio del server, senza nessun errore visibile. Ogni download, per tutta la vita di quel processo, continua a usare il vecchio formato finché non si riavvia manualmente il container.

In pratica: si cambia ad esempio la sottocartella stagione in `episode_format` da `Season_%(season:02d)` a qualcos'altro, si salva, si scarica un episodio (dalla watchlist o da ricerca manuale) — finisce comunque nella vecchia struttura di cartelle, anche se `config.json` su disco e la textarea in Settings mostrano già il nuovo valore. Fa sospettare un bug nel download quando in realtà è la UI di Settings a mentire sull'effetto immediato del salvataggio.

## Fix

`tv_display_manager.refresh_output_formats()` rilegge tutti e tre i valori da `config_manager.config`; `save_settings()` la richiama subito dopo `reload_config_only()`, nello stesso punto in cui `max_concurrent_downloads` viene già riapplicato live.

## Test

Verificato manualmente su un'istanza 1.4.0 in esecuzione: cambiato `episode_format` via l'API `save-settings` (stesso payload che manda la pagina Settings), confermato che `tv_display_manager.EPISODE_FORMAT` recepisce il nuovo valore senza alcun riavvio (prima restava indefinitamente sul vecchio).

## Nota sullo scope

Lo stesso pattern "letto una volta all'import" esiste per una ventina abbondante di altre impostazioni OUTPUT/DOWNLOAD/PROCESS/ecc. sparse tra `VibraVid/core` e `VibraVid/services` (es. `EXTENSION_OUTPUT`, `MERGE_SUBTITLES`, `USE_GPU`, `THREAD_COUNT`...). Sistemarle tutte è un lavoro di refactoring più ampio e rischioso da affrontare a parte — questa PR risolve solo i tre formati di output dietro il bug effettivamente riscontrato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)