### PR TITLE
fix(mediasetinfinity): support current season episode links

### DIFF
--- a/VibraVid/services/mediasetinfinity/scrapper.py
+++ b/VibraVid/services/mediasetinfinity/scrapper.py
@@ -176,14 +176,24 @@ class GetSerieInfo:
         if not carousel_links:
             carousel_links = soup.find_all("a", attrs={"data-testid": "carousel-title"})
         if not carousel_links:
-            logger.error(f"No titleCarousel categories found for season {season['tvSeasonNumber']}")
+            carousel_links = [
+                link
+                for link in soup.find_all("a", href=True)
+                if "/episodi_" in link.get("href", "")
+            ]
+        if not carousel_links:
+            logger.error(f"No season categories found for season {season['tvSeasonNumber']}")
             return
 
         season["categories"] = []
         for carousel_link in carousel_links:
             if carousel_link.has_attr("href"):
                 category_title = carousel_link.find("h2")
-                category_name = category_title.text.strip() if category_title else "Unnamed"
+                category_name = (
+                    category_title.text.strip()
+                    if category_title
+                    else carousel_link.get_text(" ", strip=True) or "Unnamed"
+                )
                 if any(w.lower() in category_name.lower() for w in self.BAD_WORDS):
                     continue
                 href = carousel_link["href"]


### PR DESCRIPTION
## Summary

Fix Mediaset Infinity season parsing for the current site markup.

The scraper currently looks for season category links using `a.titleCarousel` and `data-testid="carousel-title"`. Mediaset Infinity now exposes episode collections as regular links whose `href` contains `/episodi_...`.

As a result, valid season pages can return HTTP 200 while the scraper still fails to discover any episode categories.

This change:

- preserves the existing `titleCarousel` selector;
- preserves the existing `data-testid="carousel-title"` fallback;
- adds a fallback for links containing `/episodi_`;
- uses the anchor text as the category name when no `<h2>` is present;
- makes the error message generic when no season categories can be found.

## Problem

Season metadata is still discovered correctly, but `_fetch_season_categories()` returns no categories with the current Mediaset Infinity markup.

Because seasons are only added to the season manager after episodes have been collected, the GUI ultimately reports that no seasons are available even though the season pages themselves were successfully found and returned HTTP 200.

## Validation

Tested against the current `main` branch using a freshly built Docker image.

Live test case:

`R.I.S - Delitti Imperfetti`

Results:

- 5 seasons detected
- 84 episodes collected
- Season 1: 12 episodes
- Season 2: 16 episodes
- Season 3: 16 episodes
- Season 4: 20 episodes
- Season 5: 20 episodes

Additional checks:

- `python3 -m py_compile VibraVid/services/mediasetinfinity/scrapper.py`
- Docker image built successfully from the current `main` branch

## Compatibility

The new selector is only evaluated when the existing selectors return no matches.

Existing Mediaset Infinity markup using `titleCarousel` or `data-testid="carousel-title"` therefore remains supported.
