### PR TITLE
fix(mediasetinfinity): avoid using update timestamps as release year

### DIFF
--- a/VibraVid/services/mediasetinfinity/__init__.py
+++ b/VibraVid/services/mediasetinfinity/__init__.py
@@ -1,7 +1,6 @@
 ﻿# 21.05.24
 
 import re
-from datetime import datetime
 
 from rich.console import Console
 from rich.prompt import Prompt
@@ -155,14 +154,7 @@ def title_search(query: str) -> int:
         if not item.get("guid"):
             continue
 
-        date = item.get("year") or ""
-        if not date:
-            updated = item.get("updated") or item.get("r") or ""
-            if updated:
-                try:
-                    date = datetime.fromisoformat(str(updated).replace("Z", "+00:00")).year
-                except Exception:
-                    date = ""
+        date = item.get("year") or None
 
         vertical_image = None
         for img in item.get("cardImages", []):
@@ -181,7 +173,7 @@ def title_search(query: str) -> int:
                 name=item.get("cardTitle", "No Title"),
                 type=item_type,
                 image=image_url,
-                year=date if date not in ("", None) else "9999",
+                year=date,
                 url=item.get("cardLink", {}).get("value", ""),
             )
         )


### PR DESCRIPTION
## Summary

Fix incorrect release years in Mediaset Infinity search results.

## Problem

When a search result does not provide a real `year`, VibraVid currently falls back to the item's `updated` or `r` timestamp and extracts its year.

These fields represent catalog/update metadata, not the original release year. This can therefore display incorrect values such as `2026` for older series.

## What changed

- Use the real `year` field when Mediaset provides it.
- Do not derive release years from `updated` or `r`.
- Leave the year unset when Mediaset does not provide one.
- Remove the now-unused `datetime` import.

## Validation

Tested against:

- `R.I.S - Delitti Imperfetti` (`SE000000000273`)
- `R.I.S. Roma` (`SE000000000180`)

Both Mediaset metadata and GraphQL search results provide no real year for these titles.

After the fix both correctly return:

`YEAR: None`

instead of incorrectly displaying `2026`.

Additional checks:

- `python3 -m py_compile VibraVid/services/mediasetinfinity/__init__.py`
- `git diff --check`
- Docker-based live search test against Mediaset Infinity

The change is based on the upstream `Test` branch.