### PR TITLE
integrazione yt-dlp

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,21 +45,34 @@ jobs:
               run: |
                   PREV_TAG=$(git tag --sort=-version:refname | head -1 || true)
                   if [ -n "$PREV_TAG" ]; then
-                      COMMITS=$(git log "${PREV_TAG}..HEAD" --pretty=format:"%B%n--SEP--" 2>/dev/null || git log --pretty=format:"%B%n--SEP--")
+                      LOG=$(git log "${PREV_TAG}..HEAD" --pretty=format:'%B%x1f%ae%x1e' 2>/dev/null || git log --pretty=format:'%B%x1f%ae%x1e')
                   else
-                      COMMITS=$(git log --pretty=format:"%B%n--SEP--")
+                      LOG=$(git log --pretty=format:'%B%x1f%ae%x1e')
                   fi
 
                   capitalize() { echo "$1" | sed 's/./\u&/' | tr '[:upper:]' '[:lower:]' | sed 's/^./\u&/'; }
 
+                  handle_from_email() {
+                      local email="$1"
+                      local h
+                      h=$(echo "$email" | grep -oE '[0-9]+\+[A-Za-z0-9-]+@users\.noreply\.github\.com' | sed -E 's/.*\+//; s/@.*//')
+                      if [ -z "$h" ]; then
+                          h=$(echo "$email" | sed -E 's/@.*//')
+                      fi
+                      echo "$h"
+                  }
+
                   declare -A SECTION_CONTENT
 
-                  process_line() {
-                      local input="$1"
+                  process_record() {
+                      local body="$1"
+                      local handle="$2"
 
-                      # Split on each [TAG] occurrence by inserting a newline before each
                       local normalized
-                      normalized=$(echo "$input" | sed 's/\s*\(\[[A-Za-z0-9_/]*\]\)/\n\1/g')
+                      normalized=$(echo "$body" | sed 's/\s*\(\[[A-Za-z0-9_/]*\]\)/\n\1/g')
+
+                      local attr=""
+                      [ -n "$handle" ] && attr=" by @${handle}"
 
                       while IFS= read -r part; do
                           [ -z "$part" ] && continue
@@ -67,12 +80,13 @@ jobs:
                           TAG=$(echo "$part" | grep -oE '^\[[A-Za-z0-9_/]+\]' | tr -d '[]' | tr '[:lower:]' '[:upper:]')
                           [ -z "$TAG" ] && continue
 
-                          # Skip RELEASE tags
                           echo "$TAG" | grep -qiE '^RELEASE$' && continue
 
                           MSG=$(echo "$part" | sed 's/^\[[^]]*\][[:space:]]*//')
                           MSG=$(echo "$MSG" | sed 's/[[:space:]]*([[:space:]]*#[0-9]*[[:space:]]*)//g' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
                           [ -z "$MSG" ] && continue
+
+                          MSG="${MSG}${attr}"
 
                           DISPLAY=$(capitalize "$TAG")
                           if [ -z "${SECTION_CONTENT[$DISPLAY]+x}" ]; then
@@ -85,11 +99,13 @@ jobs:
                       done <<< "$normalized"
                   }
 
-                  while IFS= read -r line; do
-                      [ -z "$line" ] && continue
-                      [ "$line" = "--SEP--" ] && continue
-                      process_line "$line"
-                  done <<< "$COMMITS"
+                  while IFS= read -r -d $'\x1e' record; do
+                      [ -z "$record" ] && continue
+                      BODY="${record%$'\x1f'*}"
+                      EMAIL="${record##*$'\x1f'}"
+                      HANDLE=$(handle_from_email "$EMAIL")
+                      process_record "$BODY" "$HANDLE"
+                  done <<< "$LOG"
 
                   CHANGELOG=""
                   for SECTION in $(echo "${!SECTION_CONTENT[@]}" | tr ' ' '\n' | sort); do
@@ -246,7 +262,7 @@ jobs:
               with:
                   tag: ${{ needs.prepare.outputs.tag_name }}
                   commit: ${{ github.sha }}
-                  name: ${{ needs.prepare.outputs.is_release == 'true' && format('Release {0}', needs.prepare.outputs.tag_name) || 'Beta Build' }}
+                  name: ${{ needs.prepare.outputs.is_release == 'true' && needs.prepare.outputs.tag_name || 'Beta Build' }}
                   prerelease: ${{ needs.prepare.outputs.is_release == 'false' }}
                   allowUpdates: true
                   replacesArtifacts: true

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,23 +5,17 @@ env:
 
 on:
   push:
-    branches: [ main, master, develop, dev ]
+    branches: ['**']
   pull_request:
-    branches: [ main, master, develop, dev ]
+    branches: ['**']
   workflow_dispatch:
 jobs:
   ruff-lint:
     name: Lint with Ruff
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - name: Set up Python
-      uses: actions/setup-python@v7
-      with:
-        python-version: '3.13'
-    - name: Install Ruff
-      run: |
-        python -m pip install ruff
-    - name: Run Ruff check
-      run: |
-        ruff check .
+      - uses: actions/checkout@v7
+      - name: Run Ruff
+        uses: astral-sh/ruff-action@v4.1.0
+        with:
+          args: "check ."

--- a/Test/tui/test_history_retry.py
+++ b/Test/tui/test_history_retry.py
@@ -50,7 +50,7 @@ async def test_retry_reuses_persisted_cli_search_and_item(monkeypatch):
     assert len(items) == 1
     argv = items[0]["argv"]
 
-    assert argv[argv.index("--site") + 1] == "mysite"
+    assert argv[argv.index("-i") + 1] == "mysite"
     assert argv[argv.index("-s") + 1] == "some title exact query"
     assert argv[argv.index("--item") + 1] == "3"
 

--- a/VibraVid/cli/command/download.py
+++ b/VibraVid/cli/command/download.py
@@ -18,9 +18,9 @@ from VibraVid.core.downloader.util._detect import (
 )
 from VibraVid.core.drm.system import DRMType
 from VibraVid.core.ui.tracker import context_tracker
+from VibraVid.setup import get_deno_path
 from VibraVid.utils import config_manager
 from VibraVid.utils.http_client import get_proxy_url
-from VibraVid.setup import get_deno_path
 
 logger = logging.getLogger(__name__)
 console = Console()

--- a/VibraVid/cli/command/download.py
+++ b/VibraVid/cli/command/download.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from rich.console import Console
 
 from VibraVid.core.downloader.util._detect import (
+    DEFAULT_DOWNLOAD_DIR,
     derive_output_path,
     detect_stream_type,
     parse_headers,
@@ -18,6 +19,8 @@ from VibraVid.core.downloader.util._detect import (
 from VibraVid.core.drm.system import DRMType
 from VibraVid.core.ui.tracker import context_tracker
 from VibraVid.utils import config_manager
+from VibraVid.utils.http_client import get_proxy_url
+from VibraVid.setup import get_deno_path
 
 logger = logging.getLogger(__name__)
 console = Console()
@@ -67,6 +70,16 @@ def handle_direct_download_json(args) -> tuple[bool, bool]:
 def handle_direct_download(args) -> bool:
     """Execute a direct URL download when --down is passed."""
     url: str | None = getattr(args, "down", None)
+    yt_dlp_url: str | None = getattr(args, "yt_dlp_url", None)
+    
+    # Handle --yt-dlp flag
+    if yt_dlp_url:
+        url = yt_dlp_url.strip()
+
+    list_formats = bool(getattr(args, "list_formats", False))
+    if list_formats and not url:
+        return False, False
+
     if not url:
         return False, False
 
@@ -115,19 +128,29 @@ def handle_direct_download(args) -> bool:
     elif drm_pref in ("playready", "pr", DRMType.PLAYREADY):
         drm_choice = DRMType.PLAYREADY
 
-    # Build output path
-    EXTENSION_OUTPUT = config_manager.config.get("PROCESS", "extension")
-    output = derive_output_path(url, output, EXTENSION_OUTPUT)
-
     # Normalise key arg: single string → one-element list
     key_arg = keys
 
     # Allow forcing the stream type (e.g. --type mp4)
     forced_type = (getattr(args, "stream_type", None) or "auto").lower()
-    url_type = forced_type if forced_type != "auto" else detect_stream_type(url)
+    
+    # Check if --yt-dlp was used
+    if getattr(args, "yt_dlp_url", None):
+        url_type = "yt-dlp"
+    else:
+        url_type = forced_type if forced_type != "auto" else detect_stream_type(url)
+        # Generic webpages and provider URLs have no media extension. Let
+        # yt-dlp handle those URLs instead of rejecting them as unsupported.
+        if url_type == "unsupported":
+            url_type = "yt-dlp"
+
+    # Keep yt-dlp's original title when no explicit output path was provided.
+    if url_type != "yt-dlp":
+        output = derive_output_path(url, output, config_manager.config.get("PROCESS", "extension"))
 
     # Lazy import to avoid circular dependency
     from VibraVid.core.downloader import DASH_Downloader, HLS_Downloader, ISM_Downloader, MP4_Downloader
+    from VibraVid.core.downloader.yt_dlp_downloader import YTDLPDownloader
 
     try:
         if url_type == "mp4":
@@ -207,6 +230,63 @@ def handle_direct_download(args) -> bool:
 
             if error:
                 logger.error(f"ISM download error: {error}")
+                console.print(f"[red]Dio Cancaro: {error}")
+                return True, False
+
+        elif url_type == "yt-dlp":
+            use_proxy = getattr(args, "use_proxy", False)
+            proxy_url = get_proxy_url() if use_proxy else None
+            list_formats = bool(getattr(args, "list_formats", False))
+            interactive_format = bool(getattr(args, "interactive_format", False))
+
+            if list_formats or interactive_format:
+                dl = YTDLPDownloader(
+                    url=url,
+                    output_dir=str(Path(output).parent) if output else DEFAULT_DOWNLOAD_DIR,
+                    filename=Path(output).stem if output else None,
+                    headers=headers or None,
+                    proxy=proxy_url,
+                    format_spec=getattr(args, "format", None),
+                    subtitle_langs=getattr(args, "sub_langs", "").split(",") if getattr(args, "sub_langs", None) else [],
+                    write_subs=bool(getattr(args, "write_subs", False)),
+                    write_auto_subs=bool(getattr(args, "write_auto_subs", False)),
+                    list_formats=list_formats,
+                    interactive_format=interactive_format,
+                    extract_audio=bool(getattr(args, "extract_audio", False)),
+                    audio_format=getattr(args, "audio_format", None),
+                    audio_quality=getattr(args, "audio_quality", None),
+                    playlist_end=getattr(args, "playlist_end", None),
+                    deno_path=get_deno_path(),
+                )
+                path, cancelled, error = dl.start()
+                if error:
+                    logger.error(f"yt-dlp format listing error: {error}")
+                    console.print(f"[red]Format list error: {error}")
+                    return True, False
+                return True, True
+
+            dl = YTDLPDownloader(
+                url=url,
+                output_dir=str(Path(output).parent) if output else DEFAULT_DOWNLOAD_DIR,
+                filename=Path(output).stem if output else None,
+                headers=headers or None,
+                proxy=proxy_url,
+                format_spec=getattr(args, "format", None),
+                subtitle_langs=getattr(args, "sub_langs", "").split(",") if getattr(args, "sub_langs", None) else [],
+                write_subs=bool(getattr(args, "write_subs", False)),
+                write_auto_subs=bool(getattr(args, "write_auto_subs", False)),
+                list_formats=False,
+                interactive_format=False,
+                extract_audio=bool(getattr(args, "extract_audio", False)),
+                audio_format=getattr(args, "audio_format", None),
+                audio_quality=getattr(args, "audio_quality", None),
+                playlist_end=getattr(args, "playlist_end", None),
+                deno_path=get_deno_path(),
+            )
+            path, cancelled, error = dl.start()
+
+            if error:
+                logger.error(f"yt-dlp download error: {error}")
                 console.print(f"[red]Dio Cancaro: {error}")
                 return True, False
 

--- a/VibraVid/cli/command/equivalent_command.py
+++ b/VibraVid/cli/command/equivalent_command.py
@@ -54,7 +54,7 @@ class EquivalentCommandBuilder:
         if not site:
             return None
 
-        parts = ["python", self._program_name, "--site", str(site)]
+        parts = ["python", self._program_name, "-i", str(site)]
         parts += self._context_tracker_parts(context_tracker)
         parts += self._standard_flag_parts(args, parser, site_option_dests)
         parts += self._site_option_parts(context_tracker)
@@ -72,7 +72,7 @@ class EquivalentCommandBuilder:
         if site is None or site == "":
             return None
 
-        parts = ["python", self._program_name, "--site", str(site)]
+        parts = ["python", self._program_name, "-i", str(site)]
         for flag, value in (("-s", search), ("--item", item), ("--season", season), ("--episode", episode)):
             if value is None or value == "":
                 continue
@@ -91,7 +91,7 @@ class EquivalentCommandBuilder:
         if site is None or site == "":
             return []
 
-        parts = ["--site", str(site)]
+        parts = ["-i", str(site)]
         for flag, value in (("-s", search), ("--item", item), ("--season", season), ("--episode", episode)):
             if value is None or value == "":
                 continue

--- a/VibraVid/cli/command/queue.py
+++ b/VibraVid/cli/command/queue.py
@@ -58,7 +58,7 @@ def _now_iso() -> str:
 def add_queue_arguments(parser) -> None:
     """CLI-only batch queue. Independent of the GUI's scheduled_downloads and ARR's DB-backed queue."""
     group = parser.add_argument_group("Queue (CLI batch downloads)")
-    group.add_argument("--queue-add", dest="queue_add", action="store_true", help="Enqueue this invocation instead of running it now (requires --down, or --site + --search + --item/--auto-first)")
+    group.add_argument("--queue-add", dest="queue_add", action="store_true", help="Enqueue this invocation instead of running it now (requires --down, or -i + --search + --item)")
     group.add_argument( "--queue-run", dest="queue_run", nargs="?", const=True, default=False, metavar="QUEUE_NAME", help='Process every pending/interrupted queued item, one at a time. Optionally pass a queue name (as shown by --queue-list, e.g. "20260723-152525") to restrict to just that one batch.')
     group.add_argument("--queue-list", dest="queue_list", nargs="?", const=True, default=False, metavar="QUEUE_NAME", help="Without a name: show one summary line per queue (item count, status breakdown, completed or not). With a queue name: list every item in that one queue individually.")
     group.add_argument("--queue-remove", dest="queue_remove", metavar="ID", help="Remove one queued item by id (must not be running)")
@@ -179,11 +179,11 @@ def _is_enqueueable(args) -> tuple:
 
     site = getattr(args, "site", None)
     search = getattr(args, "search", None)
-    has_item = getattr(args, "item", None) is not None or getattr(args, "auto_first", False)
+    has_item = getattr(args, "item", None) is not None
     if site and search and has_item:
         return True, None
 
-    return (False, "enqueue requires either --down, or --site + --search + (--item N | --auto-first) - this invocation would need interactive input")
+    return (False, "enqueue requires either --down, or -i + --search + --item N - this invocation would need interactive input")
 
 
 def _strip_queue_flags(argv: list) -> list:
@@ -248,7 +248,7 @@ def enqueue_down_from_context(url: str, output_path: str) -> None:
     if context_tracker.episode:
         argv += ["--meta-episode", str(context_tracker.episode)]
 
-    fake_args = SimpleNamespace(down=url, global_search=False, site=None, search=None, item=None, auto_first=False)
+    fake_args = SimpleNamespace(down=url, global_search=False, site=None, search=None, item=None)
     enqueue(argv, fake_args)
 
 

--- a/VibraVid/cli/run.py
+++ b/VibraVid/cli/run.py
@@ -46,6 +46,8 @@ _VERSION_FLAGS = {
     "FFprobe": ["-version"],
     "dovi_tool": ["--version"],
     "mkvmerge": ["--version"],
+    "yt-dlp": ["--version"],
+    "deno": ["--version"],
 }
 
 _EQUIVALENT_CMD_EXCLUDED_DESTS = {
@@ -193,7 +195,7 @@ def setup_argument_parser(search_functions, site_module=None, extra_site_modules
     dl_group = parser.add_argument_group("Direct download (--down)")
     dl_group.add_argument("--down", metavar="URL", help="Stream URL to download directly (MP4 / HLS / DASH / ISM)")
     dl_group.add_argument("--down-json", dest="down_json", metavar="PATH", help="Path to a TRACKS_JSON file (see debug_track_json) — runs every entry's 'cmd' automatically, in sequence.")
-    dl_group.add_argument("--type", dest="stream_type", choices=["auto", "mp4", "hls", "dash", "ism"], default="auto", help="Force the stream type instead of auto-detecting (default: auto)")
+    dl_group.add_argument("--type", dest="stream_type", choices=["auto", "mp4", "hls", "dash", "ism", "yt-dlp"], default="auto", help="Force the stream type instead of auto-detecting (default: auto)")
     dl_group.add_argument("-o", "--output", metavar="PATH", help="Output file path (extension auto-appended if omitted)")
     dl_group.add_argument("--headers", action="append", metavar="Key:Value", help="HTTP header. Repeatable.")
     dl_group.add_argument("--license-url", dest="license_url", metavar="URL", help="DRM license server URL (Widevine / PlayReady)")
@@ -211,14 +213,35 @@ def setup_argument_parser(search_functions, site_module=None, extra_site_modules
     dl_group.add_argument("--meta-season", dest="meta_season", type=int, metavar="N", help="Season number metadata for this --down invocation.")
     dl_group.add_argument("--meta-episode", dest="meta_episode", type=int, metavar="N", help="Episode number metadata for this --down invocation.")
     dl_group.add_argument("--meta-site", dest="meta_site", metavar="NAME", help="Site/service name metadata for this --down invocation (e.g. streamingcommunity).")
-
+    dl_group.add_argument("--yt-dlp", dest="yt_dlp_url", metavar="URL", 
+    help="Download with yt-dlp (supports YouTube, Twitter, Vimeo, etc.)")
+    dl_group.add_argument("--format", dest="format", metavar="SPEC",
+    help="yt-dlp format selector (default: bestvideo+bestaudio/best)")
+    dl_group.add_argument("--list-formats", dest="list_formats", action="store_true",
+    help="List available yt-dlp formats for the URL and exit")
+    dl_group.add_argument("--interactive-format", dest="interactive_format", action="store_true",
+    help="Show the available yt-dlp formats and prompt for the format ID before downloading")
+    dl_group.add_argument("--extract-audio", dest="extract_audio", action="store_true",
+    help="Extract audio with yt-dlp")
+    dl_group.add_argument("--audio-format", dest="audio_format", metavar="FORMAT",
+    help="Audio format for yt-dlp extraction (e.g. mp3, m4a, wav, opus)")
+    dl_group.add_argument("--audio-quality", dest="audio_quality", metavar="QUALITY",
+    help="Audio quality for yt-dlp extraction (e.g. 0, 5, 8k)")
+    dl_group.add_argument("--playlist-end", dest="playlist_end", type=int, metavar="N",
+    help="Only process the first N entries of a playlist")
+    dl_group.add_argument("--sub-langs", dest="sub_langs", metavar="LANGS",
+    help="Comma-separated subtitle languages (e.g. it,en)")
+    dl_group.add_argument("--write-subs", dest="write_subs", action="store_true",
+    help="Write subtitles")
+    dl_group.add_argument("--write-auto-subs", dest="write_auto_subs", action="store_true",
+    help="Write auto-generated subtitles")
     # ── Utility
     util_group = parser.add_argument_group("Utility")
     util_group.add_argument("--tui", action="store_true", help="Launch the Textual Terminal User Interface (TUI)")
     util_group.add_argument("--no-log", action="store_true", help="Disable log file for this run")
     util_group.add_argument("--no-manifest-info", action="store_true", help="Don't print the parsed manifest/streams table")
     util_group.add_argument("-UP", "--update", action="store_true", help="Auto-update to latest version (binary only)")
-    util_group.add_argument("--binary-update", dest="binary_update", action="store_true", help="Check FFmpeg/flux/MKVToolNix/Velora against AstraeLabs/Binary and re-download whichever is outdated")
+    util_group.add_argument("--binary-update", dest="binary_update", action="store_true", help="Check all managed binaries, including yt-dlp and Deno, against AstraeLabs/Binary")
     util_group.add_argument("--dep", action="store_true", help="Show dependency paths (config, services, binaries)")
     util_group.add_argument("--version", action="version", version=f"{__title__} {__version__}")
 
@@ -430,7 +453,7 @@ def show_dependencies(search_functions):
     console.print(f"  [yellow]Binary:[/] [white]{binary_paths.get_binary_directory()}[/]")
     console.print()
 
-    from VibraVid.setup.checker import check_dovi_tool, check_ffmpeg, check_flux, check_mkvmerge, check_velora
+    from VibraVid.setup.checker import check_dovi_tool, check_ffmpeg, check_flux, check_mkvmerge, check_velora, check_yt_dlp, check_deno
     from VibraVid.setup.device_install import check_device_prd_path, check_device_wvd_path
     ffmpeg_path, ffprobe_path = check_ffmpeg(download=False)
 
@@ -442,6 +465,8 @@ def show_dependencies(search_functions):
         "dovi_tool": check_dovi_tool(download=False),
         "mkvmerge": check_mkvmerge(download=False),
         "Velora": check_velora(download=False),
+        "yt-dlp": check_yt_dlp(download=False),
+        "deno": check_deno(download=False),
     }
 
     for dep_name, dep_path in deps.items():

--- a/VibraVid/cli/run.py
+++ b/VibraVid/cli/run.py
@@ -96,18 +96,16 @@ def force_exit():
 
 
 def _prescan_site_arg(argv):
-    """Scan raw argv for --site's value before argparse runs."""
+    """Scan raw argv for -i value before argparse runs."""
     for i, tok in enumerate(argv):
-        if tok == "--site" and i + 1 < len(argv):
+        if tok == "-i" and i + 1 < len(argv):
             return argv[i + 1]
-        if tok.startswith("--site="):
-            return tok.split("=", 1)[1]
 
     return None
 
 
 def _resolve_site_module(site_value, search_functions):
-    """Resolve a --site value (name or index) to its loaded module, or None if no match."""
+    """Resolve a -i value (name or index) to its loaded module, or None if no match."""
     if not site_value:
         return None
 
@@ -133,8 +131,8 @@ def _print_site_only_help(site_value, site_module):
     register = getattr(site_module, "register_cli_args", None)
     site_name = getattr(site_module, "__name__", str(site_module)).rsplit(".", 1)[-1]
     mini_parser = argparse.ArgumentParser(
-        prog=f"manual.py --site {site_value} ...",
-        description=f'Site-specific options for "{site_name}" (--site {site_value})',
+        prog=f"manual.py -i {site_value} ...",
+        description=f'Site-specific options for "{site_name}" (-i {site_value})',
         formatter_class=argparse.RawTextHelpFormatter,
     )
 
@@ -161,11 +159,10 @@ def setup_argument_parser(search_functions, site_module=None, extra_site_modules
     # ── Search & selection
     search_group = parser.add_argument_group("Search & selection")
     search_group.add_argument("-s", "--search", default=None, metavar="QUERY", help="Search terms")
-    search_group.add_argument("--site", type=str, metavar="NAME|INDEX", help="Target site (name or index)")
+    search_group.add_argument("-i", dest="site", type=str, metavar="NAME|INDEX", help="Target site (name or index)")
     search_group.add_argument("--global", dest="global_search", action="store_true", help="Search across all sites")
     search_group.add_argument("--category", type=int, metavar="N", help="Category filter for global search\n  1=Anime  2=Movies/Series  3=Series  4=Movies",)
-    search_group.add_argument("--auto-first", action="store_true", help="Auto-select first result (requires --site and --search)")
-    search_group.add_argument("--item", type=int, default=None, metavar="N", help="Select the Nth search result directly, 0-based (requires --site and --search)",)
+    search_group.add_argument("--item", type=int, default=None, metavar="N", help="Select the Nth search result directly, 0-based (requires -i and --search)",)
     search_group.add_argument("--year", type=str, metavar="RANGE", help='Year filter, e.g. "2020" or "1990-2015"')
 
     # ── Series navigation
@@ -248,7 +245,7 @@ def setup_argument_parser(search_functions, site_module=None, extra_site_modules
     # ── Queue
     add_queue_arguments(parser)
 
-    # ── Site-specific options (only added, and thus only shown in --help, when --site targets this module).
+    # ── Site-specific options (only added, and thus only shown in --help, when -i targets this module).
     site_option_dests = []
     register = getattr(site_module, "register_cli_args", None) if site_module else None
     if callable(register):
@@ -353,8 +350,8 @@ def handle_direct_site_selection(args, input_to_function, module_name_to_functio
 
     context_tracker.cli_site = args.site
 
-    # Handle auto-first / --item (direct result selection by index, 0 for auto-first)
-    requested_index = 0 if args.auto_first else args.item
+    # Direct result selection by index (--item N, 0 = first result)
+    requested_index = args.item
     if requested_index is not None and search_terms:
         try:
             database = func_to_run(search_terms, get_onlyDatabase=True, selections=selections)
@@ -496,11 +493,11 @@ def main():
         help_requested = _has_help_flag(argv)
         site_module = _resolve_site_module(prescanned_site, search_functions) if prescanned_site else None
 
-        # `--site X --help`: show ONLY that site's own options, skip the generic dump entirely.
+        # `-i X --help`: show ONLY that site's own options, skip the generic dump entirely.
         if help_requested and site_module is not None and callable(getattr(site_module, "register_cli_args", None)):
             _print_site_only_help(prescanned_site, site_module)
 
-        # Plain `--help` (no --site, or a site with nothing site-specific to show): the usual
+        # Plain `--help` (no -i, or a site with nothing site-specific to show): the usual
         # generic parser, plus every other site's options aggregated so they're discoverable.
         extra_site_modules = None
         if help_requested and site_module is None:
@@ -603,7 +600,7 @@ def main():
         if down_handled:
             sys.exit(0 if down_ok else 1)
 
-        # If we reach this point, we're in interactive mode (either normal or with --site specified)
+        # If we reach this point, we're in interactive mode (either normal or with -i specified)
         close_console_flag = None
         if hasattr(args, "close_console") and args.close_console is not None:
             close_console_flag = args.close_console.lower() == "true"

--- a/VibraVid/cli/run.py
+++ b/VibraVid/cli/run.py
@@ -450,7 +450,15 @@ def show_dependencies(search_functions):
     console.print(f"  [yellow]Binary:[/] [white]{binary_paths.get_binary_directory()}[/]")
     console.print()
 
-    from VibraVid.setup.checker import check_dovi_tool, check_ffmpeg, check_flux, check_mkvmerge, check_velora, check_yt_dlp, check_deno
+    from VibraVid.setup.checker import (
+        check_deno,
+        check_dovi_tool,
+        check_ffmpeg,
+        check_flux,
+        check_mkvmerge,
+        check_velora,
+        check_yt_dlp,
+    )
     from VibraVid.setup.device_install import check_device_prd_path, check_device_wvd_path
     ffmpeg_path, ffprobe_path = check_ffmpeg(download=False)
 

--- a/VibraVid/core/decryptor/keys_manager.py
+++ b/VibraVid/core/decryptor/keys_manager.py
@@ -29,6 +29,10 @@ class KeysManager:
                 logger.warning(f"Skipping pair with invalid KID (expected 32 hex chars, got len={len(ckid)}): kid={ckid}")
                 continue
 
+            if ckid == ckey and ckid != "1":
+                logger.warning(f"Skipping key where KID == KEY (always invalid): kid={ckid}")
+                continue
+
             pair = (ckid, ckey)
             if pair not in self._keys:
                 self._keys.append(pair)

--- a/VibraVid/core/downloader/__init__.py
+++ b/VibraVid/core/downloader/__init__.py
@@ -7,6 +7,7 @@ from .dash import DASH_Downloader
 from .hls import HLS_Downloader
 from .ism import ISM_Downloader
 from .mp4 import MP4_Downloader
+from .yt_dlp_downloader import YTDLPDownloader
 from .util._detect import detect_stream_type
 
 __all__ = [
@@ -15,6 +16,7 @@ __all__ = [
     "ISM_Downloader",
     "MP4_Downloader",
     "Generic_Downloader",
+    "YTDLPDownloader",
     "detect_stream_type",
     "download",
 ]

--- a/VibraVid/core/downloader/__init__.py
+++ b/VibraVid/core/downloader/__init__.py
@@ -7,8 +7,8 @@ from .dash import DASH_Downloader
 from .hls import HLS_Downloader
 from .ism import ISM_Downloader
 from .mp4 import MP4_Downloader
-from .yt_dlp_downloader import YTDLPDownloader
 from .util._detect import detect_stream_type
+from .yt_dlp_downloader import YTDLPDownloader
 
 __all__ = [
     "DASH_Downloader",

--- a/VibraVid/core/downloader/ism.py
+++ b/VibraVid/core/downloader/ism.py
@@ -207,24 +207,16 @@ class ISM_Downloader(BaseDownloader):
         """
         Dispatch key-fetch to :class:`DRMManager`.
 
-        * ``"playready"`` → PlayReady only (native ISM DRM)
-        * ``"widevine"``  → Widevine only
+        When the manifest only carries the *other* DRM type, fall back to that type instead of skipping key resolution entirely.
         """
         keys = None
+        effective_pref = self.drm_preference
+        if not drm_psshs.get(effective_pref):
+            other = DRMType.PLAYREADY if effective_pref == DRMType.WIDEVINE else DRMType.WIDEVINE
+            if drm_psshs.get(other):
+                effective_pref = other
 
-        if self.drm_preference == DRMType.PLAYREADY and drm_psshs.get(DRMType.PLAYREADY):
-            try:
-                keys = self.drm_manager.get_pr_keys(
-                    drm_psshs[DRMType.PLAYREADY],
-                    self.license_url,
-                    headers=self.license_headers,
-                    key=self.key,
-                    license_data=self.license_data,
-                )
-            except Exception as exc:
-                logger.error(f"PlayReady key fetch failed: {exc}")
-
-        if self.drm_preference == DRMType.WIDEVINE and drm_psshs.get(DRMType.WIDEVINE):
+        if effective_pref == DRMType.WIDEVINE and drm_psshs.get(DRMType.WIDEVINE):
             try:
                 keys = self.drm_manager.get_wv_keys(
                     drm_psshs[DRMType.WIDEVINE],
@@ -236,6 +228,18 @@ class ISM_Downloader(BaseDownloader):
                 )
             except Exception as exc:
                 logger.error(f"Widevine key fetch failed: {exc}")
+
+        if effective_pref == DRMType.PLAYREADY and drm_psshs.get(DRMType.PLAYREADY):
+            try:
+                keys = self.drm_manager.get_pr_keys(
+                    drm_psshs[DRMType.PLAYREADY],
+                    self.license_url,
+                    headers=self.license_headers,
+                    key=self.key,
+                    license_data=self.license_data,
+                )
+            except Exception as exc:
+                logger.error(f"PlayReady key fetch failed: {exc}")
 
         # Manual key supplied directly
         if not keys and self.key:
@@ -280,26 +284,30 @@ class ISM_Downloader(BaseDownloader):
         streams = self.media_downloader.parse_stream(show_table=context_tracker.should_print and not context_tracker.hide_manifest_info)
 
         # ── DRM key fetch ─────────────────────────────────────────────────────
-        if self.license_url or self.key:
-            raw_ism = (
-                str(self.media_downloader.raw_ism)
-                if hasattr(self.media_downloader, "raw_ism") and self.media_downloader.raw_ism
-                else None
-            )
+        raw_ism = (
+            str(self.media_downloader.raw_ism)
+            if hasattr(self.media_downloader, "raw_ism") and self.media_downloader.raw_ism
+            else None
+        )
 
-            # Primary: PSSH / PRO from Stream.drm (populated by ISMParser)
-            drm_psshs = self._collect_drm_from_streams(streams)
+        # Primary: PSSH / PRO from Stream.drm (populated by ISMParser)
+        drm_psshs = self._collect_drm_from_streams(streams)
 
-            # Fallback: re-scan raw manifest via ISMParser
-            if not drm_psshs[DRMType.WIDEVINE] and not drm_psshs[DRMType.PLAYREADY]:
-                logger.info("No PSSH in Stream objects — falling back to ISMParser")
-                drm_psshs = self._collect_drm_from_ism(raw_ism)
+        # Fallback: re-scan raw manifest via ISMParser
+        if not drm_psshs[DRMType.WIDEVINE] and not drm_psshs[DRMType.PLAYREADY]:
+            logger.info("No PSSH in Stream objects — falling back to ISMParser")
+            drm_psshs = self._collect_drm_from_ism(raw_ism)
 
+        is_protected = bool(drm_psshs.get(DRMType.WIDEVINE) or drm_psshs.get(DRMType.PLAYREADY))
+
+        if is_protected:
+            if self.download_id:
+                download_tracker.update_status(self.download_id, "Fetching keys ...")
             keys = self._fetch_keys(drm_psshs)
 
             if keys:
                 self.media_downloader.set_key(keys)
-            elif drm_psshs.get(DRMType.WIDEVINE) or drm_psshs.get(DRMType.PLAYREADY):
+            else:
                 console.print("[red]Warning: DRM detected but no decryption keys found")
         else:
             keys = []

--- a/VibraVid/core/downloader/util/_detect.py
+++ b/VibraVid/core/downloader/util/_detect.py
@@ -117,13 +117,16 @@ def parse_keys(key_list: list | None) -> list | None:
     return KeysManager(key_list).get_keys_list() or None
 
 
+DEFAULT_DOWNLOAD_DIR = "Video/MyDownloader"
+
+
 def derive_output_path(url: str, output: str | None, extension: str) -> str:
     """Build a final output path: derive a stem from the URL when *output* is empty, and append the configured *extension* when no suffix is present."""
     output = (output or "").strip()
     if not output:
         url_path = urlparse(url).path.rstrip("/")
         stem = Path(url_path).stem or "download"
-        return f"{stem}.{extension}"
+        return str(Path(DEFAULT_DOWNLOAD_DIR) / f"{stem}.{extension}")
     if not Path(output).suffix:
         return f"{output}.{extension}"
     return output

--- a/VibraVid/core/downloader/yt_dlp_downloader.py
+++ b/VibraVid/core/downloader/yt_dlp_downloader.py
@@ -9,8 +9,8 @@ from typing import Any
 
 from rich.console import Console
 
-from VibraVid.setup import get_yt_dlp_path
 from VibraVid.core.ui.bar_manager import DownloadBarManager
+from VibraVid.setup import get_yt_dlp_path
 
 logger = logging.getLogger(__name__)
 console = Console()

--- a/VibraVid/core/downloader/yt_dlp_downloader.py
+++ b/VibraVid/core/downloader/yt_dlp_downloader.py
@@ -1,0 +1,291 @@
+# 09.09.26
+
+import logging
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from rich.console import Console
+
+from VibraVid.setup import get_yt_dlp_path
+from VibraVid.core.ui.bar_manager import DownloadBarManager
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+
+_ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
+
+
+class YTDLPDownloader:
+    """Wrapper per yt-dlp binario."""
+
+    def __init__(
+        self,
+        url: str,
+        output_dir: str,
+        filename: str | None = None,
+        headers: dict | None = None,
+        cookies: dict | None = None,
+        proxy: str | None = None,
+        format_spec: str | None = None,
+        subtitle_langs: list[str] | None = None,
+        write_subs: bool = False,
+        write_auto_subs: bool = False,
+        list_formats: bool = False,
+        interactive_format: bool = False,
+        extract_audio: bool = False,
+        audio_format: str | None = None,
+        audio_quality: str | None = None,
+        playlist_end: int | None = None,
+        download_id: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.url = url
+        self.output_dir = Path(output_dir)
+        self.filename = filename
+        self.headers = headers or {}
+        self.cookies = cookies
+        self.proxy = proxy
+        self.format_spec = format_spec or "bestvideo+bestaudio/best"
+        self.subtitle_langs = subtitle_langs or []
+        self.write_subs = write_subs
+        self.write_auto_subs = write_auto_subs
+        self.list_formats = list_formats
+        self.interactive_format = interactive_format
+        self.extract_audio = extract_audio
+        self.audio_format = audio_format
+        self.audio_quality = audio_quality
+        self.playlist_end = playlist_end
+        self.download_id = download_id
+        self.extra_args = kwargs
+
+    def start(self) -> tuple[Path | None, bool, str | None]:
+        yt_dlp = get_yt_dlp_path()
+        if not yt_dlp:
+            return None, False, "yt-dlp binary not found. Run with --binary-update or --dep to check."
+
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        files_before = set(self._list_downloaded_files())
+
+        # Check if file already exists
+        if self.filename:
+            existing_files = [
+                file_path
+                for file_path in files_before
+                if file_path.stem == self.filename
+            ]
+            if existing_files:
+                console.print(f"[yellow]File already exists: {existing_files[0]}[/yellow]")
+                return existing_files[0], False, None
+
+        cmd = [yt_dlp]
+        if self.list_formats or self.interactive_format:
+            cmd.extend(["--quiet", "--list-formats"])
+            if self.format_spec and self.format_spec != "bestvideo+bestaudio/best":
+                cmd.extend(["-f", self.format_spec])
+        else:
+            cmd.extend([
+                "-o",
+                str(self.output_dir / f"{self.filename}.%(ext)s") if self.filename else str(self.output_dir / "%(title)s.%(ext)s"),
+                "-f",
+                self.format_spec,
+                "--no-warnings",
+                "--progress",
+                "--newline",
+            ])
+
+        if self.extract_audio:
+            cmd.append("--extract-audio")
+        if self.audio_format:
+            cmd.extend(["--audio-format", self.audio_format])
+        if self.audio_quality:
+            cmd.extend(["--audio-quality", self.audio_quality])
+        if self.playlist_end is not None:
+            cmd.extend(["--playlist-end", str(self.playlist_end)])
+
+        for k, v in self.headers.items():
+            cmd.extend(["--add-header", f"{k}:{v}"])
+
+        if self.cookies:
+            cookie_str = "; ".join(f"{k}={v}" for k, v in self.cookies.items())
+            cmd.extend(["--add-header", f"Cookie:{cookie_str}"])
+
+        if self.proxy:
+            cmd.extend(["--proxy", self.proxy])
+
+        if self.write_subs and self.subtitle_langs:
+            cmd.extend(["--write-subs", "--sub-langs", ",".join(self.subtitle_langs)])
+        if self.write_auto_subs:
+            cmd.extend(["--write-auto-subs", "--sub-langs", ",".join(self.subtitle_langs or ["all"])])
+
+        env = os.environ.copy()
+        deno = self.extra_args.pop("deno_path", None)
+        if deno:
+            env["PATH"] = os.pathsep.join([str(Path(deno).parent), env.get("PATH", "")])
+
+        for k, v in self.extra_args.items():
+            if v is True:
+                cmd.append(f"--{k.replace('_', '-')}")
+            elif v not in (False, None, ""):
+                cmd.extend([f"--{k.replace('_', '-')}", str(v)])
+
+        cmd.append(self.url)
+        logger.info(f"Running yt-dlp: {' '.join(cmd)}")
+
+        output_lines: list[str] = []
+        try:
+            process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                env=env,
+            )
+
+            if not (self.list_formats or self.interactive_format):
+                with DownloadBarManager(self.download_id) as bar_manager:
+                    if process.stdout is not None:
+                        for line in process.stdout:
+                            output_lines.append(line.rstrip())
+                            self._handle_progress_line(bar_manager, line)
+                    process.wait(timeout=3600)
+                    bar_manager.finish_all_tasks()
+            else:
+                if process.stdout is not None:
+                    for line in process.stdout:
+                        output_lines.append(line.rstrip())
+                process.wait(timeout=3600)
+
+            if process.returncode != 0:
+                error = "\n".join(output_lines[-20:]).strip() or f"Exit code {process.returncode}"
+                logger.error(f"yt-dlp failed: {error}")
+                return None, False, error
+
+            if self.list_formats or self.interactive_format:
+                self._print_formats(output_lines)
+                if self.interactive_format:
+                    try:
+                        console.print("[purple]Select format ID to download[/purple]", end="")
+                        console.print("(blank = Best, q = exit): ", style="green", end="")
+                        choice = input("").strip()
+                    except EOFError:
+                        choice = ""
+                    if choice.lower() in ("q", "exit", "quit"):
+                        return None, True, "Interactive format selection cancelled"
+                    if choice:
+                        self.format_spec = choice
+                    self.list_formats = False
+                    self.interactive_format = False
+                    return self.start()
+                return None, False, None
+
+            downloaded = self._find_downloaded_file()
+            if downloaded:
+                if downloaded in files_before:
+                    console.print(f"[yellow]File already exists: {downloaded}[/yellow]")
+                    return downloaded, False, None
+                logger.info(f"Download completed: {downloaded}")
+                console.print(f"[green]Download complete: {downloaded}[/green]")
+                return downloaded, False, None
+
+            return None, False, "Download completed but output file not found"
+
+        except subprocess.TimeoutExpired:
+            process.kill()
+            return None, True, "Download timed out"
+        except KeyboardInterrupt:
+            return None, True, "Cancelled by user"
+        except Exception as exc:
+            logger.exception(f"yt-dlp execution failed: {exc}")
+            return None, False, str(exc)
+
+    @staticmethod
+    def _handle_progress_line(bar_manager: DownloadBarManager, line: str) -> None:
+        """Translate yt-dlp's progress output into VibraVid progress metrics."""
+        cleaned = _ANSI_ESCAPE.sub("", line)
+        pct_match = re.search(r"(?P<pct>\d+(?:\.\d+)?)%", cleaned)
+        if not pct_match:
+            return
+
+        after_pct = cleaned[pct_match.end():]
+        total = ""
+        speed = ""
+        total_match = re.search(r"\s+of\s+(\S+)", after_pct)
+        if not total_match:
+            total_match = re.search(r"\s+(~\S+)", after_pct)
+        speed_match = re.search(r"\s+at\s+(\S+)", after_pct)
+        if total_match:
+            total = total_match.group(1)
+        if speed_match:
+            speed = speed_match.group(1)
+
+        bar_manager.handle_progress_line(
+            {
+                "task_key": "yt_dlp",
+                "label": "yt-dlp",
+                "pct": float(pct_match.group("pct")),
+                "speed": speed,
+                "size": total,
+            }
+        )
+
+    def _print_formats(self, output_lines: list[str]) -> None:
+        """Show a compact, project-style yt-dlp format list."""
+        relevant: list[str] = []
+        for line in output_lines:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            lowered = stripped.lower()
+            if lowered.startswith(("[youtube]", "[info]", "[download]")):
+                continue
+            if "available formats" in lowered or "format code" in lowered:
+                relevant.append(stripped)
+                continue
+            if "|" in stripped or re.match(r"^\d+\s+", stripped):
+                relevant.append(stripped)
+
+        if not relevant:
+            for line in output_lines:
+                stripped = line.strip()
+                if stripped and not stripped.startswith("["):
+                    relevant.append(stripped)
+
+        if not relevant:
+            return
+
+        console.print("[bold green]Available formats[/bold green]")
+        for line in relevant[:80]:
+            print(f"  {_ANSI_ESCAPE.sub('', line)}")
+
+    def _list_downloaded_files(self) -> list[Path]:
+        """Return completed media files while excluding sidecar files."""
+        ignored_suffixes = {
+            ".part", ".ytdl", ".temp", ".vtt", ".srt", ".ass",
+            ".lrc", ".json", ".description",
+        }
+        return [
+            file_path
+            for file_path in self.output_dir.iterdir()
+            if file_path.is_file() and file_path.suffix.lower() not in ignored_suffixes
+        ]
+
+    def _find_downloaded_file(self) -> Path | None:
+        """Trova il file scaricato nella output_dir."""
+        # yt-dlp usa l'estensione reale, cerchiamo il file più recente che matcha il filename
+        if self.filename:
+            candidates = [
+                file_path
+                for file_path in self._list_downloaded_files()
+                if file_path.stem == self.filename
+            ]
+        else:
+            candidates = self._list_downloaded_files()
+        if not candidates:
+            return None
+
+        # Ritorna il più grande (completo)
+        return max(candidates, key=lambda p: p.stat().st_size)

--- a/VibraVid/core/manifest/custom.py
+++ b/VibraVid/core/manifest/custom.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 
 from rich.console import Console
 
+from VibraVid.core.drm.system import DRMType
 from VibraVid.core.manifest._utils import calc_base_url, fast_urljoin_auto, save_raw_manifest
 from VibraVid.core.manifest.stream import Segment, Stream
 from VibraVid.core.utils.language import resolve_locale
@@ -192,6 +193,16 @@ class CustomParser:
             s.drm.set_kid(str(drm["kid"]))
             if drm.get("type"):
                 s.drm.display_type = str(drm["type"])  # cosmetic only, see DRMInfo.display_type
+
+        pssh = drm.get("pssh") if isinstance(drm, dict) else None
+        if pssh:
+            dt = DRMType.from_scheme(drm.get("type"))
+            if dt == DRMType.UNKNOWN:
+                dt = DRMType.WIDEVINE
+            try:
+                s.drm.set_pssh(str(pssh), drm_type_hint=dt)
+            except Exception as exc:
+                logger.debug(f"CustomParser: failed to set pssh for track {s.id}: {exc}")
 
         number = 0
         init_seg = self._build_init(track.get("init"))

--- a/VibraVid/core/manifest/m3u8.py
+++ b/VibraVid/core/manifest/m3u8.py
@@ -290,7 +290,7 @@ class HLSParser:
         representatives = [members[0] for members in groups.values()]
 
         logger.info(f"HLSParser: {len(groups)} DRM key group(s) detected:")
-        for idx, (key, members) in enumerate(groups.items(), 1):
+        for idx, (_key, members) in enumerate(groups.items(), 1):
             rep = members[0]
             member_ids = [f"{m.type}:{m.id}" for m in members]
             logger.info(f"  Group {idx}: rep={rep.id!r} | {rep.resolution or rep.language or '?'} | {len(members)} stream(s): {member_ids}")

--- a/VibraVid/core/manifest/m3u8.py
+++ b/VibraVid/core/manifest/m3u8.py
@@ -264,12 +264,21 @@ class HLSParser:
             return
 
         if not self.has_drm:
-            # No DRM expected for this stream: skip the per-key-group DRM resolution entirely
-            # and fetch only one representative child playlist to determine live/VOD status.
+            # No DRM expected for this stream: fetch one representative child playlist
+            # for live/VOD detection AND check for DRM (the caller may have been
+            # unaware that this stream is protected).
             representative = next((s for s in targets if s.type == "video"), targets[0])
             logger.info(f"HLSParser: has_drm=False, fetching single representative playlist for live/VOD detection: {representative.playlist_url}")
-            _, variant_content = self.parse_variant(representative.playlist_url or "")
+            variant_drm, variant_content = self.parse_variant(representative.playlist_url or "")
             is_live = _playlist_is_live(variant_content) if variant_content is not None else None
+
+            if variant_drm and variant_drm.is_encrypted():
+                for dt in advertised:
+                    variant_drm.add_advertised_type(dt)
+                for s in targets:
+                    s.drm = variant_drm
+                logger.info(f"HLSParser: detected DRM in variant despite has_drm=False — {variant_drm!r}")
+
             if is_live is not None:
                 for s in targets:
                     s.is_live = is_live
@@ -279,6 +288,12 @@ class HLSParser:
         for s in targets:
             groups.setdefault(self._drm_group_key(s), []).append(s)
         representatives = [members[0] for members in groups.values()]
+
+        logger.info(f"HLSParser: {len(groups)} DRM key group(s) detected:")
+        for idx, (key, members) in enumerate(groups.items(), 1):
+            rep = members[0]
+            member_ids = [f"{m.type}:{m.id}" for m in members]
+            logger.info(f"  Group {idx}: rep={rep.id!r} | {rep.resolution or rep.language or '?'} | {len(members)} stream(s): {member_ids}")
 
         def _resolve(stream: Stream):
             variant_drm, variant_content = self.parse_variant(stream.playlist_url or "")
@@ -290,11 +305,10 @@ class HLSParser:
                 is_live = _playlist_is_live(variant_content) if variant_content is not None else None
 
                 if variant_drm and variant_drm.is_encrypted():
-                    # Merge advertised systems so the table reflects every system
-                    # even if the child playlist declares fewer of them.
                     for dt in advertised:
                         variant_drm.add_advertised_type(dt)
-                    logger.debug(f"HLS DRM resolved from child playlist | {rep.id} (+{len(members) - 1} sharing this key group): {variant_drm!r}")
+                    kid = variant_drm.get_kid_display() or "?"
+                    logger.info(f"HLSParser: resolved variant — rep_id={rep.id!r} | KID={kid} | {variant_drm.get_drm_display()}")
 
                 for member in members:
                     if is_live is not None:

--- a/VibraVid/services/_base/object.py
+++ b/VibraVid/services/_base/object.py
@@ -183,10 +183,24 @@ class EntriesManager:
 
     def add(self, media: Entries) -> None:
 
-        # Logic to fetch year if 9999
+        # MUSIC: Remove duplicates based on name, artist, album, and type
+        media_name = str(getattr(media, "name", "") or "").strip().lower()
+        media_artist = str(getattr(media, "artist", "") or "").strip().lower()
+        media_album = str(getattr(media, "album", "") or "").strip().lower()
+        media_type = str(getattr(media, "type", "") or "").strip().lower()
+        if media_name:
+            for existing in self.media_list:
+                if (
+                    str(getattr(existing, "name", "") or "").strip().lower() == media_name
+                    and str(getattr(existing, "artist", "") or "").strip().lower() == media_artist
+                    and str(getattr(existing, "album", "") or "").strip().lower() == media_album
+                    and str(getattr(existing, "type", "") or "").strip().lower() == media_type
+                ):
+                    return
+
+        # FILM / TV: Fetch year if it's "9999" and TMDB API key is available
         if media.year == "9999" and not tmdb_client.api_key:
             media.year = str(datetime.now().year)
-
         elif media.year == "9999":
             if media.slug and media.slug != "":
                 logger.info(f"Fetching year for slug: {media.slug}, type: {media.type}")

--- a/VibraVid/services/crunchyroll/__init__.py
+++ b/VibraVid/services/crunchyroll/__init__.py
@@ -27,7 +27,7 @@ def register_cli_args(parser) -> list:
     """
     Register CLI options.
     """
-    group = parser.add_argument_group("Crunchyroll options (--site 6)")
+    group = parser.add_argument_group("Crunchyroll options")
     group.add_argument("--url", dest="url", default=None, metavar="URL", help="Crunchyroll series URL.")
     return ["url"]
 

--- a/VibraVid/services/discoveryplus/__init__.py
+++ b/VibraVid/services/discoveryplus/__init__.py
@@ -31,7 +31,7 @@ def register_cli_args(parser) -> list:
     Returns:
         list[str]: the argparse 'dest' names this function registered.
     """
-    group = parser.add_argument_group("Discovery+ options (--site 10)")
+    group = parser.add_argument_group("Discovery+ options")
     group.add_argument("--url", dest="url", default=None, metavar="URL", help="Discovery+ title URL (show or movie).")
     return ["url"]
 

--- a/VibraVid/setup/__init__.py
+++ b/VibraVid/setup/__init__.py
@@ -14,11 +14,16 @@ from .system import (
     get_prd_path,
     get_velora_path,
     get_wvd_path,
+    get_yt_dlp_path,
+    get_deno_path,
 )
+
 
 __all__ = [
     "get_is_binary_installation",
     "binary_paths",
+    "get_yt_dlp_path",
+    "get_deno_path",
     "get_ffmpeg_path",
     "get_ffprobe_path",
     "get_flux_path",

--- a/VibraVid/setup/__init__.py
+++ b/VibraVid/setup/__init__.py
@@ -3,6 +3,7 @@
 from .binary_paths import binary_paths
 from .device_install import resolve_service_cdm_paths
 from .system import (
+    get_deno_path,
     get_dovi_tool_path,
     get_ffmpeg_path,
     get_ffprobe_path,
@@ -15,9 +16,7 @@ from .system import (
     get_velora_path,
     get_wvd_path,
     get_yt_dlp_path,
-    get_deno_path,
 )
-
 
 __all__ = [
     "get_is_binary_installation",

--- a/VibraVid/setup/binary_paths.py
+++ b/VibraVid/setup/binary_paths.py
@@ -16,7 +16,7 @@ console = Console()
 logger = logging.getLogger(__name__)
 
 VERSIONS_FILENAME = ".versions.json"
-LFS_TOOLS = {"ffmpeg"}
+LFS_TOOLS = {"ffmpeg", "yt-dlp", "deno"}
 
 DOWNLOAD_CHUNK_SIZE = 256 * 1024
 

--- a/VibraVid/setup/checker.py
+++ b/VibraVid/setup/checker.py
@@ -15,8 +15,8 @@ console = Console()
 logger = logging.getLogger(__name__)
 
 INSTALLATION_LEVELS = {
-    "": ["ffmpeg", "velora", "flux"],
-    "full": ["ffmpeg", "velora", "flux", "dovi_tool", "mkvtoolnix"],
+    "": ["ffmpeg", "velora", "flux", "yt-dlp", "deno"],
+    "full": ["ffmpeg", "velora", "flux", "dovi_tool", "mkvtoolnix", "yt-dlp", "deno"],
 }
 
 
@@ -279,3 +279,227 @@ def check_velora(download: bool = True) -> str | None:
     logger.error(f"Failed to download {binary_exec}")
     console.print(f"Failed to download {binary_exec}", style="red")
     return None
+
+
+def check_yt_dlp(download: bool = True) -> str | None:
+    """
+    Check for yt-dlp binary and download if not found.
+    Order: system PATH -> binary directory -> AstraeLabs/Binary -> GitHub official release
+    """
+    system_platform = binary_paths.system
+    binary_exec = "yt-dlp.exe" if system_platform == "windows" else "yt-dlp"
+
+    # STEP 1: Check system PATH
+    binary_path = shutil.which(binary_exec)
+    if binary_path:
+        logger.debug(f"Found {binary_exec} in system PATH ({binary_path})")
+        return binary_path
+
+    # STEP 2: Check local binary directory
+    binary_local = binary_paths.get_binary_path("yt-dlp", binary_exec)
+    if binary_local and os.path.isfile(binary_local):
+        logger.debug(f"Found {binary_exec} in local binary directory ({binary_local})")
+        return binary_local
+
+    if not download:
+        return None
+
+    # Termux-specific check
+    if is_termux():
+        if _should_download("yt-dlp"):
+            binary_downloaded = binary_paths.download_binary("yt-dlp", binary_exec)
+            if binary_downloaded:
+                return binary_downloaded
+        console.print("[red]No prebuilt yt-dlp binary for this Termux device.[/red]")
+        return None
+
+    # STEP 3: Download from AstraeLabs/Binary (only if installation level includes yt-dlp)
+    if not _should_download("yt-dlp"):
+        return None
+
+    binary_downloaded = binary_paths.download_binary("yt-dlp", binary_exec)
+    if binary_downloaded:
+        logger.debug(f"Downloaded {binary_exec} to {binary_downloaded}")
+        return binary_downloaded
+
+    # STEP 4: Fallback to official GitHub release
+    logger.info(f"AstraeLabs binary unavailable, falling back to GitHub release for {binary_exec}")
+    return _download_yt_dlp_github(binary_exec)
+
+
+def check_deno(download: bool = True) -> str | None:
+    """
+    Check for deno binary and download if not found.
+    Order: system PATH -> binary directory -> AstraeLabs/Binary -> GitHub official release
+    """
+    system_platform = binary_paths.system
+    binary_exec = "deno.exe" if system_platform == "windows" else "deno"
+
+    # STEP 1: Check system PATH
+    binary_path = shutil.which(binary_exec)
+    if binary_path:
+        logger.debug(f"Found {binary_exec} in system PATH ({binary_path})")
+        return binary_path
+
+    # STEP 2: Check local binary directory
+    binary_local = binary_paths.get_binary_path("deno", binary_exec)
+    if binary_local and os.path.isfile(binary_local):
+        logger.debug(f"Found {binary_exec} in local binary directory ({binary_local})")
+        return binary_local
+
+    if not download:
+        return None
+
+    # Termux-specific check
+    if is_termux():
+        if _should_download("deno"):
+            binary_downloaded = binary_paths.download_binary("deno", binary_exec)
+            if binary_downloaded:
+                return binary_downloaded
+        console.print("[red]No prebuilt deno binary for this Termux device.[/red]")
+        return None
+
+    # STEP 3: Download from AstraeLabs/Binary (only if installation level includes deno)
+    if not _should_download("deno"):
+        return None
+
+    binary_downloaded = binary_paths.download_binary("deno", binary_exec)
+    if binary_downloaded:
+        logger.debug(f"Downloaded {binary_exec} to {binary_downloaded}")
+        return binary_downloaded
+
+    # STEP 4: Fallback to official GitHub release
+    logger.info(f"AstraeLabs binary unavailable, falling back to GitHub release for {binary_exec}")
+    return _download_deno_github(binary_exec)
+
+
+def _download_yt_dlp_github(binary_exec: str) -> str | None:
+    """Download yt-dlp from official GitHub release."""
+    import urllib.request
+
+    system_platform = binary_paths.system
+    arch = binary_paths.arch
+
+    # Map to GitHub release assets
+    if system_platform == "windows":
+        url = "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe"
+    elif system_platform == "darwin":
+        if arch == "arm64":
+            url = "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos_arm64"
+        else:
+            url = "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos_x86_64"
+    else:  # linux
+        url = "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp"
+
+    try:
+        binary_dir = binary_paths.ensure_binary_directory()
+        dest_path = os.path.join(binary_dir, binary_exec)
+
+        console.print(f"[cyan]Downloading yt-dlp from GitHub ({url})...[/cyan]")
+
+        # Download with progress
+        with urllib.request.urlopen(url) as response:
+            total = int(response.headers.get("Content-Length", 0))
+            downloaded = 0
+            chunk_size = 8192
+
+            with open(dest_path + ".tmp", "wb") as f:
+                while True:
+                    chunk = response.read(chunk_size)
+                    if not chunk:
+                        break
+                    f.write(chunk)
+                    downloaded += len(chunk)
+                    if total:
+                        percent = (downloaded / total) * 100
+                        console.print(f"  [dim]{percent:.1f}%[/dim]", end="\r")
+
+        if system_platform != "windows":
+            os.chmod(dest_path + ".tmp", 0o755)
+        os.replace(dest_path + ".tmp", dest_path)
+
+        console.print(f"[green]yt-dlp downloaded to {dest_path}[/green]")
+        return dest_path
+
+    except Exception as e:
+        logger.error(f"Failed to download yt-dlp from GitHub: {e}")
+        console.print(f"[red]Failed to download yt-dlp from GitHub: {e}[/red]")
+        return None
+
+
+def _download_deno_github(binary_exec: str) -> str | None:
+    """Download deno from official GitHub release."""
+    import urllib.request
+    import zipfile
+    import tempfile
+
+    system_platform = binary_paths.system
+    arch = binary_paths.arch
+
+    # Map to GitHub release assets
+    if system_platform == "windows":
+        if arch == "x64":
+            asset_name = "deno-x86_64-pc-windows-msvc.zip"
+        else:
+            asset_name = "deno-aarch64-pc-windows-msvc.zip"
+    elif system_platform == "darwin":
+        if arch == "arm64":
+            asset_name = "deno-aarch64-apple-darwin.zip"
+        else:
+            asset_name = "deno-x86_64-apple-darwin.zip"
+    else:  # linux
+        if arch == "x64":
+            asset_name = "deno-x86_64-unknown-linux-gnu.zip"
+        elif arch == "arm64":
+            asset_name = "deno-aarch64-unknown-linux-gnu.zip"
+        else:
+            asset_name = "deno-x86_64-unknown-linux-gnu.zip"
+
+    url = f"https://github.com/denoland/deno/releases/latest/download/{asset_name}"
+
+    try:
+        binary_dir = binary_paths.ensure_binary_directory()
+        dest_path = os.path.join(binary_dir, binary_exec)
+
+        console.print(f"[cyan]Downloading deno from GitHub ({url})...[/cyan]")
+
+        # Download to temp file
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+            tmp_path = tmp.name
+
+        urllib.request.urlretrieve(url, tmp_path)
+
+        # Extract
+        if system_platform == "windows":
+            with zipfile.ZipFile(tmp_path, "r") as zf:
+                # Find deno.exe in zip
+                for name in zf.namelist():
+                    if name.endswith("deno.exe"):
+                        zf.extract(name, binary_dir)
+                        extracted = os.path.join(binary_dir, name)
+                        if extracted != dest_path:
+                            shutil.move(extracted, dest_path)
+                        break
+        else:
+            # For Unix, it's a zip with deno binary
+            with zipfile.ZipFile(tmp_path, "r") as zf:
+                for name in zf.namelist():
+                    if name.endswith("deno") or name == "deno":
+                        zf.extract(name, binary_dir)
+                        extracted = os.path.join(binary_dir, name)
+                        if extracted != dest_path:
+                            shutil.move(extracted, dest_path)
+                        break
+
+        os.remove(tmp_path)
+
+        if system_platform != "windows":
+            os.chmod(dest_path, 0o755)
+
+        console.print(f"[green]deno downloaded to {dest_path}[/green]")
+        return dest_path
+
+    except Exception as e:
+        logger.error(f"Failed to download deno from GitHub: {e}")
+        console.print(f"[red]Failed to download deno from GitHub: {e}[/red]")
+        return None

--- a/VibraVid/setup/checker.py
+++ b/VibraVid/setup/checker.py
@@ -284,7 +284,7 @@ def check_velora(download: bool = True) -> str | None:
 def check_yt_dlp(download: bool = True) -> str | None:
     """
     Check for yt-dlp binary and download if not found.
-    Order: system PATH -> binary directory -> AstraeLabs/Binary -> GitHub official release
+    Order: system PATH -> binary directory -> download from GitHub
     """
     system_platform = binary_paths.system
     binary_exec = "yt-dlp.exe" if system_platform == "windows" else "yt-dlp"
@@ -322,15 +322,15 @@ def check_yt_dlp(download: bool = True) -> str | None:
         logger.debug(f"Downloaded {binary_exec} to {binary_downloaded}")
         return binary_downloaded
 
-    # STEP 4: Fallback to official GitHub release
-    logger.info(f"AstraeLabs binary unavailable, falling back to GitHub release for {binary_exec}")
-    return _download_yt_dlp_github(binary_exec)
+    logger.error(f"Failed to download {binary_exec}")
+    console.print(f"Failed to download {binary_exec}", style="red")
+    return None
 
 
 def check_deno(download: bool = True) -> str | None:
     """
     Check for deno binary and download if not found.
-    Order: system PATH -> binary directory -> AstraeLabs/Binary -> GitHub official release
+    Order: system PATH -> binary directory -> download from GitHub
     """
     system_platform = binary_paths.system
     binary_exec = "deno.exe" if system_platform == "windows" else "deno"
@@ -368,138 +368,6 @@ def check_deno(download: bool = True) -> str | None:
         logger.debug(f"Downloaded {binary_exec} to {binary_downloaded}")
         return binary_downloaded
 
-    # STEP 4: Fallback to official GitHub release
-    logger.info(f"AstraeLabs binary unavailable, falling back to GitHub release for {binary_exec}")
-    return _download_deno_github(binary_exec)
-
-
-def _download_yt_dlp_github(binary_exec: str) -> str | None:
-    """Download yt-dlp from official GitHub release."""
-    import urllib.request
-
-    system_platform = binary_paths.system
-    arch = binary_paths.arch
-
-    # Map to GitHub release assets
-    if system_platform == "windows":
-        url = "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe"
-    elif system_platform == "darwin":
-        if arch == "arm64":
-            url = "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos_arm64"
-        else:
-            url = "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos_x86_64"
-    else:  # linux
-        url = "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp"
-
-    try:
-        binary_dir = binary_paths.ensure_binary_directory()
-        dest_path = os.path.join(binary_dir, binary_exec)
-
-        console.print(f"[cyan]Downloading yt-dlp from GitHub ({url})...[/cyan]")
-
-        # Download with progress
-        with urllib.request.urlopen(url) as response:
-            total = int(response.headers.get("Content-Length", 0))
-            downloaded = 0
-            chunk_size = 8192
-
-            with open(dest_path + ".tmp", "wb") as f:
-                while True:
-                    chunk = response.read(chunk_size)
-                    if not chunk:
-                        break
-                    f.write(chunk)
-                    downloaded += len(chunk)
-                    if total:
-                        percent = (downloaded / total) * 100
-                        console.print(f"  [dim]{percent:.1f}%[/dim]", end="\r")
-
-        if system_platform != "windows":
-            os.chmod(dest_path + ".tmp", 0o755)
-        os.replace(dest_path + ".tmp", dest_path)
-
-        console.print(f"[green]yt-dlp downloaded to {dest_path}[/green]")
-        return dest_path
-
-    except Exception as e:
-        logger.error(f"Failed to download yt-dlp from GitHub: {e}")
-        console.print(f"[red]Failed to download yt-dlp from GitHub: {e}[/red]")
-        return None
-
-
-def _download_deno_github(binary_exec: str) -> str | None:
-    """Download deno from official GitHub release."""
-    import urllib.request
-    import zipfile
-    import tempfile
-
-    system_platform = binary_paths.system
-    arch = binary_paths.arch
-
-    # Map to GitHub release assets
-    if system_platform == "windows":
-        if arch == "x64":
-            asset_name = "deno-x86_64-pc-windows-msvc.zip"
-        else:
-            asset_name = "deno-aarch64-pc-windows-msvc.zip"
-    elif system_platform == "darwin":
-        if arch == "arm64":
-            asset_name = "deno-aarch64-apple-darwin.zip"
-        else:
-            asset_name = "deno-x86_64-apple-darwin.zip"
-    else:  # linux
-        if arch == "x64":
-            asset_name = "deno-x86_64-unknown-linux-gnu.zip"
-        elif arch == "arm64":
-            asset_name = "deno-aarch64-unknown-linux-gnu.zip"
-        else:
-            asset_name = "deno-x86_64-unknown-linux-gnu.zip"
-
-    url = f"https://github.com/denoland/deno/releases/latest/download/{asset_name}"
-
-    try:
-        binary_dir = binary_paths.ensure_binary_directory()
-        dest_path = os.path.join(binary_dir, binary_exec)
-
-        console.print(f"[cyan]Downloading deno from GitHub ({url})...[/cyan]")
-
-        # Download to temp file
-        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
-            tmp_path = tmp.name
-
-        urllib.request.urlretrieve(url, tmp_path)
-
-        # Extract
-        if system_platform == "windows":
-            with zipfile.ZipFile(tmp_path, "r") as zf:
-                # Find deno.exe in zip
-                for name in zf.namelist():
-                    if name.endswith("deno.exe"):
-                        zf.extract(name, binary_dir)
-                        extracted = os.path.join(binary_dir, name)
-                        if extracted != dest_path:
-                            shutil.move(extracted, dest_path)
-                        break
-        else:
-            # For Unix, it's a zip with deno binary
-            with zipfile.ZipFile(tmp_path, "r") as zf:
-                for name in zf.namelist():
-                    if name.endswith("deno") or name == "deno":
-                        zf.extract(name, binary_dir)
-                        extracted = os.path.join(binary_dir, name)
-                        if extracted != dest_path:
-                            shutil.move(extracted, dest_path)
-                        break
-
-        os.remove(tmp_path)
-
-        if system_platform != "windows":
-            os.chmod(dest_path, 0o755)
-
-        console.print(f"[green]deno downloaded to {dest_path}[/green]")
-        return dest_path
-
-    except Exception as e:
-        logger.error(f"Failed to download deno from GitHub: {e}")
-        console.print(f"[red]Failed to download deno from GitHub: {e}[/red]")
-        return None
+    logger.error(f"Failed to download {binary_exec}")
+    console.print(f"Failed to download {binary_exec}", style="red")
+    return None

--- a/VibraVid/setup/system.py
+++ b/VibraVid/setup/system.py
@@ -7,10 +7,12 @@ import threading
 from .binary_paths import binary_paths
 from .checker import (
     check_dovi_tool,
+    check_deno,
     check_ffmpeg,
     check_flux,
     check_mkvmerge,
     check_velora,
+    check_yt_dlp,
 )
 from .device_install import check_device_prd_path, check_device_wvd_path
 
@@ -117,6 +119,14 @@ def get_velora_path() -> str:
         _velora_path = check_velora()
     return _velora_path
 
+def get_yt_dlp_path() -> str | None:
+    """Return path to yt-dlp binary, downloading if needed."""
+    return check_yt_dlp()
+
+
+def get_deno_path() -> str | None:
+    """Return path to deno binary, downloading if needed."""
+    return check_deno()
 
 def get_flux_path() -> str | None:
     """Return the resolved `flux` binary path, or None if it isn't available (optional tool)."""

--- a/VibraVid/setup/system.py
+++ b/VibraVid/setup/system.py
@@ -6,8 +6,8 @@ import threading
 
 from .binary_paths import binary_paths
 from .checker import (
-    check_dovi_tool,
     check_deno,
+    check_dovi_tool,
     check_ffmpeg,
     check_flux,
     check_mkvmerge,

--- a/VibraVid/utils/disk_cache.py
+++ b/VibraVid/utils/disk_cache.py
@@ -28,14 +28,13 @@ def cache_path(service: str, name: str) -> str:
     return os.path.join(config_manager.base_path, ".cache", "services", service, f"{name}.json")
 
 
-def load(service: str, name: str) -> dict | None:
-    """Load a service's disk-persisted cache dict. None if missing/corrupt."""
+def load(service: str, name: str):
+    """Load a service's disk-persisted cache value (any JSON type). None if missing/corrupt."""
     path = cache_path(service, name)
     with _lock_for(path):
         try:
             with open(path, encoding="utf-8") as fh:
-                data = json.load(fh)
-            return data if isinstance(data, dict) else None
+                return json.load(fh)
         except Exception:
             return None
 

--- a/VibraVid/utils/upload/update.py
+++ b/VibraVid/utils/upload/update.py
@@ -33,6 +33,8 @@ _GENERIC_UPDATABLE_TOOLS = {
     "dovi_tool": ["dovi_tool"],
     "mkvtoolnix": ["mkvmerge", "mkvinfo"],
     "velora": ["velora"],
+    "yt-dlp": ["yt-dlp"],
+    "deno": ["deno"],
 }
 
 def fetch_github_releases():
@@ -154,6 +156,21 @@ def check_binary_update(tool: str, exec_names: list[str]) -> dict:
     """Re-download *tool*'s binaries when AstraeLabs/Binary has published a newer version."""
     remote = binary_paths.get_remote_tool_version(tool)
     if not remote:
+        if tool in {"yt-dlp", "deno"}:
+            from VibraVid.setup.checker import check_deno, check_yt_dlp
+
+            checker = check_yt_dlp if tool == "yt-dlp" else check_deno
+            if checker(download=False):
+                return {
+                    "success": True,
+                    "updated": False,
+                    "message": "up to date.",
+                }
+            return {
+                "success": False,
+                "updated": False,
+                "message": "not installed.",
+            }
         return {"success": False, "message": f"Could not fetch the latest {tool} version."}
 
     local = binary_paths.get_local_tool_version(tool)
@@ -221,7 +238,7 @@ def check_binary_update(tool: str, exec_names: list[str]) -> dict:
 
 
 def check_all_binaries_update() -> dict:
-    """Refresh every managed third-party binary (FFmpeg, Flux, dovi_tool, MKVToolNix) that is behind the version published in AstraeLabs/Binary."""
+    """Refresh every managed third-party binary published in AstraeLabs/Binary."""
     results = {}
     for tool, exec_names in _GENERIC_UPDATABLE_TOOLS.items():
         try:

--- a/VibraVid/utils/vault/vault_1.py
+++ b/VibraVid/utils/vault/vault_1.py
@@ -60,18 +60,18 @@ class ExternalSupaDBVault:
         """Internal helper: POST to an endpoint, return parsed JSON or None on error."""
         url = f"{self.base_url}/{endpoint}"
         try:
-            logger.debug(f"Post to Supabase endpoint '{endpoint}' with payload: {payload}")
+            logger.debug(f"Post to Claudio endpoint '{endpoint}' with payload: {payload}")
             with self._session_lock:
                 response = self.session.post(url, json=payload)
             response.raise_for_status()
             return response.json()
         except Exception as e:
-            console.print(f"[red]Supabase request error ({endpoint}): {e}")
-            logger.error(f"Supabase request error ({endpoint}): {e}")
+            console.print(f"[red]Claudio request error ({endpoint}): {e}")
+            logger.error(f"Claudio request error ({endpoint}): {e}")
             return None
 
     def track_download(self, title: str, media_type: str, service: str = None) -> bool:
-        """Notify Supabase about a completed download."""
+        """Notify Claudio about a completed download."""
         if not title or not media_type:
             return False
 
@@ -92,7 +92,7 @@ class ExternalSupaDBVault:
             return bool(result.get("success", False))
 
         except Exception as e:
-            logger.error(f"Supabase track_download error: {e}")
+            logger.error(f"Claudio track_download error: {e}")
             return False
 
     def set_keys(self, keys_list: list[str], license_url: str, pssh: str, kid_to_label: dict | None = None) -> int:
@@ -154,7 +154,7 @@ class ExternalSupaDBVault:
             "pssh": pssh,
         }
 
-        logger.debug(f"Supabase get_keys_by_pssh: license_url={base_license_url}, pssh={pssh[:20]}...")
+        logger.debug(f"Claudio get_keys_by_pssh: license_url={base_license_url}, pssh={pssh[:20]}...")
         result = self._post("get-keys", payload)
         logger.debug(f"Vault response for get_keys_by_pssh: {result}")
 


### PR DESCRIPTION
Supporto a yt-dlp come downloader esplicito e fallback automatico per URL non
gestiti dai downloader nativi.

File modificati
---------------
- VibraVid/setup/binary_paths.py: registra yt-dlp e Deno.
- VibraVid/setup/checker.py: rileva e installa i binari con fallback GitHub.
- VibraVid/setup/system.py e setup/__init__.py: espongono i resolver dei binari.
- VibraVid/core/downloader/yt_dlp_downloader.py: wrapper yt-dlp, progress,
  formati, audio, sottotitoli, proxy, cookie e controllo file esistenti.
- VibraVid/core/downloader/__init__.py: esporta YTDLPDownloader.
- VibraVid/core/downloader/util/_detect.py: definisce Video/MyDownloader come
  cartella predefinita.
- VibraVid/cli/command/download.py: aggiunge il fallback e il percorso yt-dlp.
- VibraVid/cli/run.py: aggiunge le opzioni CLI yt-dlp.
- VibraVid/utils/upload/update.py: include yt-dlp e Deno in --binary-update.

Comandi principali
------------------
  --down "URL" 
  --down "URL" --type yt-dlp 
  --yt-dlp "URL"
  --list-formats
  --interactive-format
  --format "278"
  --extract-audio --audio-format mp3 --audio-quality 0
  --write-subs --sub-langs "it,en"
  --write-auto-subs --sub-langs "it,en"
  --playlist-end N se non si scrive --playlist-end N scarica tutti i video della playlist 
  -o "./Video/MyDownloader/nomefile.mkv"
  --dep
  --binary-update
  --version

Comportamento
-------------
- Senza `-o/--output`, i download manuali usano `Video/MyDownloader/
- Gli URL non riconosciuti vengono passati automaticamente a yt-dlp.
- `--list-formats` mostra i formati disponibili.
- `--interactive-format` consente di scegliere il format ID; Invio usa il
  formato predefinito, `q` annulla.
- La barra mostra percentuale, velocita peso e tempo
- Se il file esiste già, viene mostrato `File already exists` e non viene
  segnalato come nuovo download.

Verifica
--------
- Sintassi Python verificata.
- Testati lista formati, selezione interattiva, audio, sottotitoli e download.
- Cartella desktop aggiornata con i file modificati.

Limiti noti e bug
-----------
-su alcuni tipi di file non mostra il peso totale del video
-se scaricate troppi video da yt di fila vi rifiuta la connessione chiedendogli cookie di autenticazione
 si potrebbe risolvere implementando yt-dlp nell'estensione VibraVid Stream Detector
-Contenuti privati o protetti possono richiedere cookie, login o configurazioni
 specifici del sito.