### PR TITLE
fix(eurostreaming): decode WordPress HTML entities

### DIFF
--- a/VibraVid/services/eurostreaming/__init__.py
+++ b/VibraVid/services/eurostreaming/__init__.py
@@ -1,6 +1,7 @@
 # 29.05.26
 # By @UrloMythus
 
+import html
 import logging
 import re
 
@@ -52,7 +53,7 @@ def title_search(query: str) -> int:
                 post_resp = client.get(f"{base_url}/wp-json/wp/v2/posts/{post_id}", params={"_fields": "content,title"})
             post_resp.raise_for_status()
             data = post_resp.json()
-            title = data.get("title", {}).get("rendered", "")
+            title = html.unescape(data.get("title", {}).get("rendered", ""))
             content = data.get("content", {}).get("rendered", "")
 
             year_m = _YEAR_RE.search(content)

--- a/VibraVid/services/eurostreaming/scrapper.py
+++ b/VibraVid/services/eurostreaming/scrapper.py
@@ -2,6 +2,7 @@
 # By @UrloMythus
 
 import difflib
+import html
 import logging
 import re
 import threading
@@ -17,8 +18,8 @@ _YEAR_RE = re.compile(r"(?<![/\d])(19|20)\d{2}(?![/\d])")
 
 class GetSerieInfo:
     def __init__(self, series_name: str, base_url: str):
-        self.series_name = series_name
-        self.series_display_name = series_name
+        self.series_name = html.unescape(series_name)
+        self.series_display_name = self.series_name
         self.base_url = base_url.rstrip("/")
         self.year = None
         self.seasons_manager = SeasonManager()
@@ -63,7 +64,7 @@ class GetSerieInfo:
                     )
                     post_resp.raise_for_status()
                     data = post_resp.json()
-                    title = data.get("title", {}).get("rendered", "")
+                    title = html.unescape(data.get("title", {}).get("rendered", ""))
                     content = data.get("content", {}).get("rendered", "")
 
                     ratio = difflib.SequenceMatcher(None, title.lower(), self.series_name.lower()).ratio()
@@ -100,7 +101,7 @@ class GetSerieInfo:
                     rf"{season_num}&#215;{ep_num:02d}\s*[-–]\s*([^<\n]+)",
                     self._content,
                 )
-                ep_title = title_m.group(1).strip() if title_m else f"Episodio {ep_num}"
+                ep_title = html.unescape(title_m.group(1).strip()) if title_m else f"Episodio {ep_num}"
                 em.add(Episode(id=ep_num, number=ep_num, name=ep_title))
 
             s = Season(id=season_num, number=season_num, name=f"Stagione {season_num}", slug="")


### PR DESCRIPTION
## Summary

Fix Eurostreaming series metadata lookup when WordPress returns HTML-encoded titles such as `R.I.S. &#8211; Delitti imperfetti`.

The search result was passing the encoded title to `GetSerieInfo`, which then reused it as a WordPress search query. Eurostreaming returns no results for that encoded query, causing series details to report zero seasons.

## Changes

- decode WordPress-rendered titles before storing search results
- normalize `series_name` inside `GetSerieInfo`
- decode fetched series titles before fuzzy matching and display
- decode episode titles parsed from WordPress HTML

No downloader or hoster logic is changed.

## Verification

Before the fix:

- `R.I.S. &#8211; Delitti imperfetti` -> 0 seasons
- WordPress search using the encoded title -> 0 results

With the decoded title:

- `R.I.S. – Delitti imperfetti` -> 5 seasons with 6, 8, 16, 20 and 20 episodes
- `R.I.S. Roma – Delitti imperfetti` -> 3 seasons with 20 episodes each
- existing MaxStream hoster links are still discovered correctly for tested episodes

The fix makes the normal search/GUI path use decoded titles automatically.