### PR TITLE
feat(eurostreaming): add artwork support

### DIFF
--- a/VibraVid/services/_base/tmdb_artwork.py
+++ b/VibraVid/services/_base/tmdb_artwork.py
@@ -9,6 +9,7 @@ from VibraVid.utils import config_manager
 logger = logging.getLogger(__name__)
 _TV_MATCH_SITES = {
     "streamingcommunity",
+    "eurostreaming",
     "altadefinizione",
     "cinezo",
     "tubitv",

--- a/VibraVid/services/eurostreaming/__init__.py
+++ b/VibraVid/services/eurostreaming/__init__.py
@@ -50,11 +50,20 @@ def title_search(query: str) -> int:
 
         try:
             with create_client(headers=headers) as client:
-                post_resp = client.get(f"{base_url}/wp-json/wp/v2/posts/{post_id}", params={"_fields": "content,title"})
+                post_resp = client.get(
+                    f"{base_url}/wp-json/wp/v2/posts/{post_id}",
+                    params={
+                        "_embed": "wp:featuredmedia",
+                        "_fields": "content,title,_embedded",
+                    },
+                )
             post_resp.raise_for_status()
             data = post_resp.json()
             title = html.unescape(data.get("title", {}).get("rendered", ""))
             content = data.get("content", {}).get("rendered", "")
+
+            embedded_media = (data.get("_embedded") or {}).get("wp:featuredmedia") or []
+            image = embedded_media[0].get("source_url") if embedded_media else None
 
             year_m = _YEAR_RE.search(content)
             year = year_m.group(0) if year_m else None
@@ -66,6 +75,7 @@ def title_search(query: str) -> int:
                     type="tv",
                     slug="",
                     year=year,
+                    image=image,
                 )
             )
 


### PR DESCRIPTION
## Summary

- fetch Eurostreaming's native featured image through the existing WordPress post request using `wp:featuredmedia`
- store the featured image URL in the search entry so the GUI can display the provider's poster
- enable Eurostreaming in TMDB TV matching so series/episode artwork can fall back to TMDB when needed

## Validation

- `git diff --check`
- Python AST parsing for both modified files
- live Eurostreaming search verified with native posters
- TMDB series matching and episode artwork resolver verified end-to-end through the GUI resolver